### PR TITLE
fix: correct tilt direction, double-rotation, calibration preview, dr…

### DIFF
--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -63,9 +63,11 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
     const imgH = fov.imageHeightAtDistance;
 
     // ── Pan/Tilt offsets ──
-    const tiltOffsetPx = (cam.tilt / fov.verticalDeg) * H;
-    const cameraHeightFraction = cam.z / imgH;
-    const groundY = H * (0.5 - cameraHeightFraction) - tiltOffsetPx;
+    // For a level camera the horizon sits at H/2 regardless of camera height — cam.z only
+    // affects where individual objects project (handled in worldToScreen below).
+    // Positive tilt = looking up → horizon must move DOWN in the frame (larger y).
+    const tiltOffsetPx = (Math.tan((cam.tilt * Math.PI) / 180) / Math.tan((fov.verticalDeg / 2) * Math.PI / 180)) * (H / 2);
+    const groundY = H * 0.5 + tiltOffsetPx;
     const groundYClamped = Math.max(-H, Math.min(H * 2, groundY));
 
 
@@ -132,7 +134,9 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       const tiltRad = (c.tilt * Math.PI) / 180;
       const apparentY = (wz - c.z) / localZ;
       const tiltShift = Math.tan(tiltRad);
-      const screenY = H / 2 - ((apparentY + tiltShift) / Math.tan(fovVRad)) * (H / 2);
+      // Positive tilt (look up) rotates the world DOWN in camera frame → subtract tiltShift
+      // so that ground objects move toward the bottom of the screen as tilt increases.
+      const screenY = H / 2 - ((apparentY - tiltShift) / Math.tan(fovVRad)) * (H / 2);
       return { sx: screenX, sy: screenY, dist: localZ, behindCamera: false };
     };
     const worldToScreenLocal = worldToScreen;

--- a/src/components/Sidebar/Calculator.tsx
+++ b/src/components/Sidebar/Calculator.tsx
@@ -1,6 +1,3 @@
-import { useStore } from '../../store/useStore';
-import { CAMERAS } from '../../data/cameras';
-import { LENSES, getCompatibleLenses } from '../../data/lenses';
 import { SENSORS } from '../../data/cameras';
 import { computeFov, computeDof, personHeightInFrame } from '../../utils/fov';
 import { useState } from 'react';

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -158,10 +158,15 @@ function CameraCard({ camId }: { camId: string }) {
                 const newCam = getCameraById(e.target.value);
                 if (!newCam) return;
                 const lens = getCompatibleLenses(newCam.mount, newCam.adaptedMounts)[0];
+                const supportsExtender = cam.extenderActive === 1 || !!lens?.extenderFactors?.includes(cam.extenderActive);
                 updateCamera(cam.id, {
                   cameraId: e.target.value,
                   lensId: lens?.id ?? cam.lensId,
                   focalLength: lens?.focalLengthMin ?? cam.focalLength,
+                  aperture: lens?.maxApertureWide ?? cam.aperture,
+                  extenderActive: supportsExtender ? cam.extenderActive : 1,
+                  // Speedbooster only valid on MFT cameras with EF lenses
+                  useSpeedbooster: newCam.mount === 'MFT' && lens?.mount === 'EF' ? cam.useSpeedbooster : false,
                 });
               }}
             >
@@ -192,10 +197,15 @@ function CameraCard({ camId }: { camId: string }) {
               onChange={(e) => {
                 if (e.target.value === '__new__') { setShowNewLens(true); return; }
                 const lens = getLensById(e.target.value) ?? customLenses.find((l) => l.id === e.target.value);
+                const supportsExtender = cam.extenderActive === 1 || !!lens?.extenderFactors?.includes(cam.extenderActive);
                 updateCamera(cam.id, {
                   lensId: e.target.value,
                   focalLength: lens?.focalLengthMin ?? cam.focalLength,
                   aperture: lens?.maxApertureWide ?? cam.aperture,
+                  // Reset extender when switching to a lens that doesn't support the current value
+                  extenderActive: supportsExtender ? cam.extenderActive : 1,
+                  // Speedbooster only makes sense with an EF lens on an MFT body
+                  useSpeedbooster: camDef?.mount === 'MFT' && lens?.mount === 'EF' ? cam.useSpeedbooster : false,
                 });
               }}
             >
@@ -212,7 +222,24 @@ function CameraCard({ camId }: { camId: string }) {
           {/* Custom lens: delete button for active custom lens */}
           {lensDef?.isCustom && (
             <button
-              onClick={() => { removeCustomLens(cam.lensId); const first = compatDeduped.find(l => !l.isCustom); if (first) updateCamera(cam.id, { lensId: first.id, focalLength: first.focalLengthMin }); }}
+              onClick={() => {
+                // Pick a replacement BEFORE removing — prefer a built-in compatible lens,
+                // then fall back to any non-removed custom lens, and finally any LENSES entry.
+                const replacement =
+                  compatDeduped.find((l) => !l.isCustom && l.id !== cam.lensId) ??
+                  compatDeduped.find((l) => l.id !== cam.lensId) ??
+                  LENSES[0];
+                removeCustomLens(cam.lensId);
+                if (replacement) {
+                  const supportsExtender = cam.extenderActive === 1 || !!replacement.extenderFactors?.includes(cam.extenderActive);
+                  updateCamera(cam.id, {
+                    lensId: replacement.id,
+                    focalLength: replacement.focalLengthMin,
+                    aperture: replacement.maxApertureWide,
+                    extenderActive: supportsExtender ? cam.extenderActive : 1,
+                  });
+                }
+              }}
               className="text-[10px] text-bc-red hover:text-red-400 mt-0.5"
             >Remove custom lens "{lensDef.manufacturer} {lensDef.model}"</button>
           )}
@@ -445,7 +472,7 @@ export default function Sidebar() {
     cameras, addCamera, venue, setVenue, showAllFov, toggleShowAllFov, clearAll,
     pixelsPerMeter, setPixelsPerMeter,
     addStage, removeStage, updateStage,
-    persons, addPerson, addStageObject, removePerson,
+    persons, addPerson, addStageObject, removePerson, updatePerson,
     backgroundPlan, setBackgroundPlan,
     walls, addWall, removeWall, updateWall,
   } = useStore();
@@ -688,7 +715,7 @@ export default function Sidebar() {
                   p.objectType === 'mic-stand' ? '🎤' : '👤'
                 }</span>
                 <input className="bg-transparent text-white text-xs w-16 outline-none" value={p.label}
-                  onChange={(e) => useStore.getState().updatePerson(p.id, { label: e.target.value })} />
+                  onChange={(e) => updatePerson(p.id, { label: e.target.value })} />
                 <span className="text-gray-500">{p.height}m</span>
                 <span className="text-gray-500">({p.x.toFixed(1)}, {p.y.toFixed(1)})</span>
                 <button onClick={() => removePerson(p.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>

--- a/src/components/Venue2D/Venue2D.tsx
+++ b/src/components/Venue2D/Venue2D.tsx
@@ -65,6 +65,7 @@ export default function Venue2D() {
   const [calibAutoResize, setCalibAutoResize] = useState(true);
   const [calibScaleLocked, setCalibScaleLocked] = useState(true);
   const [calibPoints, setCalibPoints] = useState<{ x: number; y: number }[]>([]);
+  const [calibCursor, setCalibCursor] = useState<{ x: number; y: number } | null>(null);
 
   const ppm = pixelsPerMeter;
   const W = venue.widthM * ppm;
@@ -186,6 +187,7 @@ export default function Venue2D() {
       setCalibAutoResize(autoResize ?? true);
       setCalibScaleLocked(scaleLocked ?? false);
       setCalibPoints([]);
+      setCalibCursor(null);
     };
     window.addEventListener('multicam-calibrate', handler);
     return () => window.removeEventListener('multicam-calibrate', handler);
@@ -264,16 +266,21 @@ export default function Venue2D() {
 
       setCalibActive(false);
       setCalibPoints([]);
+      setCalibCursor(null);
       window.dispatchEvent(new CustomEvent('multicam-calibrate-done'));
     }
   }, [addWall, backgroundPlan, calibActive, calibAutoResize, calibAxis, calibDistM, calibPoints, calibScaleLocked, drawingWall, getPointerWorldPoint, ppm, setBackgroundPlan, setVenue, snapPoint, venue, wallStart, walls.length]);
 
   const handleStageMouseMove = useCallback(() => {
-    if (!drawingWall || !wallStart) return;
     const point = getPointerWorldPoint();
     if (!point) return;
-    setWallCursor(snapPoint(wallStart, { x: point.xPx / ppm, y: point.yPx / ppm }));
-  }, [drawingWall, getPointerWorldPoint, ppm, snapPoint, wallStart]);
+    if (drawingWall && wallStart) {
+      setWallCursor(snapPoint(wallStart, { x: point.xPx / ppm, y: point.yPx / ppm }));
+    }
+    if (calibActive && calibPoints.length === 1) {
+      setCalibCursor({ x: point.xPx, y: point.yPx });
+    }
+  }, [calibActive, calibPoints.length, drawingWall, getPointerWorldPoint, ppm, snapPoint, wallStart]);
 
   const handleWallEndpointDragMove = useCallback((wall: Wall, end: 'start' | 'end', e: Konva.KonvaEventObject<DragEvent>) => {
     const node = e.target;
@@ -291,27 +298,37 @@ export default function Venue2D() {
 
   const handleCamDragEnd = useCallback(
     (cam: VenueCamera, e: Konva.KonvaEventObject<DragEvent>) => {
-      const newX = e.target.x() / ppm;
-      const newY = e.target.y() / ppm;
-      moveCamera(cam.id, Math.max(0, Math.min(venue.widthM, newX)), Math.max(0, Math.min(venue.heightM, newY)));
+      const newX = Math.max(0, Math.min(venue.widthM, e.target.x() / ppm));
+      const newY = Math.max(0, Math.min(venue.heightM, e.target.y() / ppm));
+      // Sync Konva's internal position back to the clamped value — otherwise the visual
+      // can stay at the out-of-bounds drag position when React doesn't re-render
+      // (e.g. when the clamped value equals the previous state).
+      e.target.position({ x: newX * ppm, y: newY * ppm });
+      moveCamera(cam.id, newX, newY);
     },
     [moveCamera, ppm, venue],
   );
 
   const handleStageDragEnd = useCallback(
     (stageId: string, e: Konva.KonvaEventObject<DragEvent>) => {
-      const newX = e.target.x() / ppm;
-      const newY = e.target.y() / ppm;
-      updateStage(stageId, { x: Math.max(0, newX), y: Math.max(0, newY) });
+      const stage = venue.stages.find((s) => s.id === stageId);
+      if (!stage) return;
+      const maxX = Math.max(0, venue.widthM - stage.width);
+      const maxY = Math.max(0, venue.heightM - stage.height);
+      const newX = Math.max(0, Math.min(maxX, e.target.x() / ppm));
+      const newY = Math.max(0, Math.min(maxY, e.target.y() / ppm));
+      e.target.position({ x: newX * ppm, y: newY * ppm });
+      updateStage(stageId, { x: newX, y: newY });
     },
-    [updateStage, ppm],
+    [updateStage, ppm, venue],
   );
 
   const handlePersonDragEnd = useCallback(
     (personId: string, e: Konva.KonvaEventObject<DragEvent>) => {
-      const newX = e.target.x() / ppm;
-      const newY = e.target.y() / ppm;
-      updatePerson(personId, { x: Math.max(0, Math.min(venue.widthM, newX)), y: Math.max(0, Math.min(venue.heightM, newY)) });
+      const newX = Math.max(0, Math.min(venue.widthM, e.target.x() / ppm));
+      const newY = Math.max(0, Math.min(venue.heightM, e.target.y() / ppm));
+      e.target.position({ x: newX * ppm, y: newY * ppm });
+      updatePerson(personId, { x: newX, y: newY });
     },
     [updatePerson, ppm, venue],
   );
@@ -484,8 +501,18 @@ export default function Venue2D() {
               <Text x={p.x + 8} y={p.y - 6} text={`P${i + 1}`} fontSize={11} fill="#22c55e" fontStyle="bold" listening={false} />
             </Group>
           ))}
-          {calibPoints.length === 1 && (
-            <Line points={[calibPoints[0].x, calibPoints[0].y, calibPoints[0].x, calibPoints[0].y]} stroke="#22c55e" strokeWidth={2} dash={[6, 4]} listening={false} />
+          {calibPoints.length === 1 && calibCursor && (
+            <Line
+              points={
+                calibAxis === 'x'
+                  ? [calibPoints[0].x, calibPoints[0].y, calibCursor.x, calibPoints[0].y]
+                  : [calibPoints[0].x, calibPoints[0].y, calibPoints[0].x, calibCursor.y]
+              }
+              stroke="#22c55e"
+              strokeWidth={2}
+              dash={[6, 4]}
+              listening={false}
+            />
           )}
         </Layer>
       )}

--- a/src/components/Venue3D/Venue3D.tsx
+++ b/src/components/Venue3D/Venue3D.tsx
@@ -355,10 +355,10 @@ function FovPyramid({ cam, isSelected }: { cam: ReturnType<typeof useStore.getSt
     return geo;
   }, [isZoom, fovMax.horizontalDeg, fovMax.verticalDeg, cam.focusDistance]);
 
-  const tiltRad = (cam.tilt * Math.PI) / 180;
-
   return (
-    <group rotation={[tiltRad, -Math.PI / 2, 0]}>
+    // Tilt is applied by the parent `pitchRef` group in CameraRig — only reorient the
+    // pyramid (modeled along -Z) so it points along the camera's local +X (pan axis).
+    <group rotation={[0, -Math.PI / 2, 0]}>
       {/* Camera body */}
       <mesh>
         <boxGeometry args={[0.3, 0.2, 0.4]} />

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -163,29 +163,34 @@ export const useStore = create<AppState>((set, get) => ({
 
   // ── Stages ──
   addStage: (partial) => {
-    const { venue } = get();
-    const newStage: Stage = {
-      id: stageUid(),
-      x: partial?.x ?? venue.widthM / 2 - 3,
-      y: partial?.y ?? 0.5,
-      width: partial?.width ?? 6,
-      height: partial?.height ?? 3,
-      label: partial?.label ?? `Stage ${venue.stages.length + 1}`,
-    };
-    set((s) => ({ venue: { ...venue, stages: [...venue.stages, newStage] }, projectVersion: s.projectVersion + 1 }));
+    set((s) => {
+      const newStage: Stage = {
+        id: stageUid(),
+        x: partial?.x ?? s.venue.widthM / 2 - 3,
+        y: partial?.y ?? 0.5,
+        width: partial?.width ?? 6,
+        height: partial?.height ?? 3,
+        label: partial?.label ?? `Stage ${s.venue.stages.length + 1}`,
+      };
+      return {
+        venue: { ...s.venue, stages: [...s.venue.stages, newStage] },
+        projectVersion: s.projectVersion + 1,
+      };
+    });
   },
 
   removeStage: (id) => {
-    const { venue } = get();
-    set((s) => ({ venue: { ...venue, stages: venue.stages.filter((st) => st.id !== id) }, projectVersion: s.projectVersion + 1 }));
+    set((s) => ({
+      venue: { ...s.venue, stages: s.venue.stages.filter((st) => st.id !== id) },
+      projectVersion: s.projectVersion + 1,
+    }));
   },
 
   updateStage: (id, updates) => {
-    const { venue } = get();
     set((s) => ({
       venue: {
-        ...venue,
-        stages: venue.stages.map((st) => (st.id === id ? { ...st, ...updates } : st)),
+        ...s.venue,
+        stages: s.venue.stages.map((st) => (st.id === id ? { ...st, ...updates } : st)),
       },
       projectVersion: s.projectVersion + 1,
     }));
@@ -199,33 +204,35 @@ export const useStore = create<AppState>((set, get) => ({
   persons: [],
 
   addPerson: (x, y) => {
-    const { venue, persons } = get();
-    const newPerson: ReferencePerson = {
-      id: personUid(),
-      x: x ?? venue.widthM / 2,
-      y: y ?? venue.heightM / 2,
-      height: 1.8,
-      width: 0.5,
-      label: `Person ${persons.length + 1}`,
-      objectType: 'person',
-    };
-    set((s) => ({ persons: [...s.persons, newPerson], projectVersion: s.projectVersion + 1 }));
+    set((s) => {
+      const newPerson: ReferencePerson = {
+        id: personUid(),
+        x: x ?? s.venue.widthM / 2,
+        y: y ?? s.venue.heightM / 2,
+        height: 1.8,
+        width: 0.5,
+        label: `Person ${s.persons.length + 1}`,
+        objectType: 'person',
+      };
+      return { persons: [...s.persons, newPerson], projectVersion: s.projectVersion + 1 };
+    });
   },
 
   addStageObject: (objectType, x, y) => {
-    const { venue, persons } = get();
-    const preset = OBJECT_PRESETS[objectType] ?? OBJECT_PRESETS['custom'];
-    const count = persons.filter((p) => p.objectType === objectType).length;
-    const newObj: ReferencePerson = {
-      id: personUid(),
-      x: x ?? venue.widthM / 2,
-      y: y ?? venue.heightM / 2,
-      height: preset.height,
-      width: preset.width,
-      label: `${preset.label} ${count + 1}`,
-      objectType,
-    };
-    set((s) => ({ persons: [...s.persons, newObj], projectVersion: s.projectVersion + 1 }));
+    set((s) => {
+      const preset = OBJECT_PRESETS[objectType] ?? OBJECT_PRESETS['custom'];
+      const count = s.persons.filter((p) => p.objectType === objectType).length;
+      const newObj: ReferencePerson = {
+        id: personUid(),
+        x: x ?? s.venue.widthM / 2,
+        y: y ?? s.venue.heightM / 2,
+        height: preset.height,
+        width: preset.width,
+        label: `${preset.label} ${count + 1}`,
+        objectType,
+      };
+      return { persons: [...s.persons, newObj], projectVersion: s.projectVersion + 1 };
+    });
   },
 
   removePerson: (id) => set((s) => ({ persons: s.persons.filter((p) => p.id !== id), projectVersion: s.projectVersion + 1 })),
@@ -277,8 +284,10 @@ export const useStore = create<AppState>((set, get) => ({
     const { cameras, selectedCameraId } = get();
     if (cameras.length === 0) return;
     const idx = cameras.findIndex((c) => c.id === selectedCameraId);
-    const prev = cameras[(idx - 1 + cameras.length) % cameras.length];
-    set({ selectedCameraId: prev.id });
+    // When no camera is selected (idx === -1), wrap around to the last camera so
+    // "previous" feels like stepping backwards from the start of the list.
+    const prevIdx = idx < 0 ? cameras.length - 1 : (idx - 1 + cameras.length) % cameras.length;
+    set({ selectedCameraId: cameras[prevIdx].id });
   },
 
   toggleFavoriteCameraId: (id) => {
@@ -302,34 +311,35 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   addCamera: (cameraId, lensId) => {
-    const cam = cameraId ? CAMERAS.find((c) => c.id === cameraId) : CAMERAS[0];
-    const camDef = cam ?? CAMERAS[0];
-    const allLenses = [...LENSES, ...get().customLenses];
-    const lens = lensId
-      ? allLenses.find((l) => l.id === lensId)
-      : allLenses.find((l) => l.mount === camDef.mount) ?? allLenses[0];
-    const lensDef = lens ?? allLenses[0];
-    const { venue, cameras } = get();
-    const idx = cameras.length;
-    const newCam: VenueCamera = {
-      id: uid(),
-      label: `CAM ${idx + 1}`,
-      cameraId: camDef.id,
-      lensId: lensDef.id,
-      x: venue.widthM / 2,
-      y: venue.heightM * 0.75,
-      z: 1.5,
-      pan: -90,
-      tilt: 0,
-      focalLength: lensDef.focalLengthMin,
-      aperture: lensDef.maxApertureWide,
-      focusDistance: venue.heightM * 0.5,
-      color: CAMERA_COLORS[idx % CAMERA_COLORS.length],
-      extenderActive: 1,
-      useSpeedbooster: false,
-      mountType: 'tripod',
-    };
-    set((s) => ({ cameras: [...s.cameras, newCam], selectedCameraId: newCam.id, projectVersion: s.projectVersion + 1 }));
+    set((s) => {
+      const cam = cameraId ? CAMERAS.find((c) => c.id === cameraId) : CAMERAS[0];
+      const camDef = cam ?? CAMERAS[0];
+      const allLenses = [...LENSES, ...s.customLenses];
+      const lens = lensId
+        ? allLenses.find((l) => l.id === lensId)
+        : allLenses.find((l) => l.mount === camDef.mount) ?? allLenses[0];
+      const lensDef = lens ?? allLenses[0];
+      const idx = s.cameras.length;
+      const newCam: VenueCamera = {
+        id: uid(),
+        label: `CAM ${idx + 1}`,
+        cameraId: camDef.id,
+        lensId: lensDef.id,
+        x: s.venue.widthM / 2,
+        y: s.venue.heightM * 0.75,
+        z: 1.5,
+        pan: -90,
+        tilt: 0,
+        focalLength: lensDef.focalLengthMin,
+        aperture: lensDef.maxApertureWide,
+        focusDistance: s.venue.heightM * 0.5,
+        color: CAMERA_COLORS[idx % CAMERA_COLORS.length],
+        extenderActive: 1,
+        useSpeedbooster: false,
+        mountType: 'tripod',
+      };
+      return { cameras: [...s.cameras, newCam], selectedCameraId: newCam.id, projectVersion: s.projectVersion + 1 };
+    });
   },
 
   removeCamera: (id) =>
@@ -352,35 +362,37 @@ export const useStore = create<AppState>((set, get) => ({
     })),
 
   duplicateCamera: (id) => {
-    const { cameras } = get();
-    const src = cameras.find((c) => c.id === id);
-    if (!src) return;
-    const idx = cameras.length;
-    const dup: VenueCamera = {
-      ...src,
-      id: uid(),
-      label: `CAM ${idx + 1}`,
-      x: src.x + 1,
-      y: src.y + 1,
-      color: CAMERA_COLORS[idx % CAMERA_COLORS.length],
-    };
-    set((s) => ({ cameras: [...s.cameras, dup], selectedCameraId: dup.id, projectVersion: s.projectVersion + 1 }));
+    set((s) => {
+      const src = s.cameras.find((c) => c.id === id);
+      if (!src) return s;
+      const idx = s.cameras.length;
+      const dup: VenueCamera = {
+        ...src,
+        id: uid(),
+        label: `CAM ${idx + 1}`,
+        x: src.x + 1,
+        y: src.y + 1,
+        color: CAMERA_COLORS[idx % CAMERA_COLORS.length],
+      };
+      return { cameras: [...s.cameras, dup], selectedCameraId: dup.id, projectVersion: s.projectVersion + 1 };
+    });
   },
 
   // ── Walls ──
   walls: [],
   addWall: (wall) => {
-    const { venue } = get();
-    const w: Wall = {
-      id: uid('wall'),
-      x1: wall?.x1 ?? 0,
-      y1: wall?.y1 ?? venue.heightM / 2,
-      x2: wall?.x2 ?? venue.widthM,
-      y2: wall?.y2 ?? venue.heightM / 2,
-      height: wall?.height ?? 3,
-      label: wall?.label ?? 'Wall',
-    };
-    set((s) => ({ walls: [...s.walls, w], projectVersion: s.projectVersion + 1 }));
+    set((s) => {
+      const w: Wall = {
+        id: uid('wall'),
+        x1: wall?.x1 ?? 0,
+        y1: wall?.y1 ?? s.venue.heightM / 2,
+        x2: wall?.x2 ?? s.venue.widthM,
+        y2: wall?.y2 ?? s.venue.heightM / 2,
+        height: wall?.height ?? 3,
+        label: wall?.label ?? `Wall ${s.walls.length + 1}`,
+      };
+      return { walls: [...s.walls, w], projectVersion: s.projectVersion + 1 };
+    });
   },
   removeWall: (id) => set((s) => ({ walls: s.walls.filter((w) => w.id !== id), projectVersion: s.projectVersion + 1 })),
   updateWall: (id, updates) => set((s) => ({ walls: s.walls.map((w) => (w.id === id ? { ...w, ...updates } : w)), projectVersion: s.projectVersion + 1 })),
@@ -403,14 +415,18 @@ export const useStore = create<AppState>((set, get) => ({
     const tmpl = all.find((t) => t.id === templateId);
     if (!tmpl) return;
     nextId = 1;
+    stageId = 1;
+    personId = 1;
     const cams: VenueCamera[] = tmpl.cameras.map((c) => ({ ...c, id: uid(), useSpeedbooster: c.useSpeedbooster ?? false }));
-    set({
+    set((s) => ({
       venue: { ...tmpl.venue },
       cameras: cams,
       selectedCameraId: cams[0]?.id ?? null,
       persons: [],
+      walls: [],
       backgroundPlan: null,
-    });
+      projectVersion: s.projectVersion + 1,
+    }));
   },
 
   saveAsTemplate: (name, category) => {


### PR DESCRIPTION
…ag clamping, state setters

Calculations / display:
- CameraPreview: invert tilt sign so positive tilt (look up) moves horizon and ground objects DOWN in the frame, not UP. Also use accurate tan-based offset and stop letting camera height shift the horizon away from the geometric center for a level camera.
- Venue3D FovPyramid: remove redundant tiltRad rotation — the pitchRef parent already applies tilt, so the pyramid was being tilted twice (e.g. 2× -30° instead of -30°).

Venue 2D:
- Calibration preview line now tracks the cursor along the active axis instead of being a zero-length line at the first point.
- Stage / camera / person drag-end now clamps within venue bounds AND syncs Konva's internal position back so out-of-bounds drags no longer leave the visual stuck past the clamped value. Stages are kept fully inside the venue (right/bottom edges, not just left/top).

Store:
- loadTemplate now resets walls, the stage/person ID counters, and bumps projectVersion so the unsaved-changes badge reflects the new project.
- selectPrevCamera wraps to the last camera when no camera is selected (instead of jumping to the second-to-last via -2 modulo).
- Stage/person/wall/camera/duplicate setters use the s.venue/s.cameras from inside Zustand's set callback rather than a captured `get()` snapshot — prevents lost updates when actions fire in quick succession (duplicated "Stage N" labels, racing camera additions, etc.).

Sidebar:
- Camera switch now also updates aperture, resets the extender if the new lens doesn't support it, and clears useSpeedbooster when no longer valid.
- Lens switch resets extender when the new lens has no matching extender factor and clears useSpeedbooster for non-MFT/EF combinations.
- Custom lens deletion now picks a non-custom replacement first (and falls back to LENSES[0]) so deleting the last compatible custom lens no longer leaves the camera with an undefined lensId; aperture and extender are also reset to match the replacement.
- Use the destructured updatePerson instead of useStore.getState().updatePerson for consistency.

Calculator:
- Remove unused imports (CAMERAS, LENSES, getCompatibleLenses, useStore).

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr