### PR TITLE
v0.4.0 — multi-export, sensor modes, custom cameras, focus pick + bühnen-clipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multicam-planner",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Multicam Broadcast Camera & Lens Planner – FOV/DoF calculator, 2D/3D venue planner, dynamic preview",
   "main": "electron/main.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multicam-planner",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Multicam Broadcast Camera & Lens Planner – FOV/DoF calculator, 2D/3D venue planner, dynamic preview",
   "main": "electron/main.cjs",
   "type": "module",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -380,6 +380,43 @@ export default function App() {
     return () => mq.removeEventListener('change', handler);
   }, [setSidebarCollapsed]);
 
+  // ── Expose layout-prep hook for the export panel ──
+  // Capturing each panel requires it to be visible at non-zero size. In Focus mode
+  // only one tab is rendered visibly, so we switch to Grid for the duration of the
+  // export and restore the previous layout afterwards.
+  useEffect(() => {
+    (window as any).__multicamPrepareForExport = async () => {
+      const previousMode = layoutMode;
+      const previousFocusTab = focusTabId;
+      const previousModelJson = model.toJson();
+      if (previousMode !== 'grid') {
+        applyLayoutJson(createGridLayoutJson());
+        setLayoutMode('grid');
+        // Wait long enough for FlexLayout to mount the new tabsets, for
+        // ResizeObservers to fire on each panel container, and for Konva/R3F to
+        // paint at least one frame at the new dimensions.
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => {
+            setTimeout(resolve, 250);
+          }));
+        });
+      }
+      return {
+        restore: () => {
+          if (previousMode === 'focus') {
+            setLayoutMode('focus');
+            setFocusTabId(previousFocusTab);
+            applyLayoutJson(createFocusLayoutJson(previousFocusTab));
+          } else if (previousMode === 'custom') {
+            setLayoutMode('custom');
+            applyLayoutJson(previousModelJson);
+          }
+        },
+      };
+    };
+    return () => { delete (window as any).__multicamPrepareForExport; };
+  }, [applyLayoutJson, focusTabId, layoutMode, model]);
+
   return (
     <div className="h-screen flex flex-col bg-bc-dark text-gray-200">
       <Header

--- a/src/components/Export/ExportPanel.tsx
+++ b/src/components/Export/ExportPanel.tsx
@@ -5,19 +5,26 @@ import { getLensById } from '../../data/lenses';
 import { computeFov, computeDof, personHeightInFrame } from '../../utils/fov';
 import type { VenueCamera } from '../../types';
 
+export type ExportMode = 'current' | 'all' | 'widetele' | 'all-widetele';
+
+interface ExportDetail {
+  mode?: ExportMode;
+}
+
 /**
  * Listens for the 'multicam-export' custom event and generates a combined PNG
  * containing: camera label, 2D plan, 3D screenshot, Preview, and Calculator data.
+ *
+ * The detail.mode controls which renders are emitted:
+ *   - 'current'       → one PNG of the currently-selected camera at its current focal length
+ *   - 'all'           → one PNG per camera at each camera's current focal length
+ *   - 'widetele'      → two PNGs for the selected camera: at min and max focal length
+ *   - 'all-widetele'  → two PNGs per camera (wide + tele)
  */
 export default function ExportPanel() {
   const [exporting, setExporting] = useState(false);
-  const { cameras, selectedCameraId, venue, persons, projectVersion } = useStore();
-
-  const cam = cameras.find((c) => c.id === selectedCameraId);
-
-  const captureCanvas = useCallback((selector: string): HTMLCanvasElement | null => {
-    return document.querySelector(selector) as HTMLCanvasElement | null;
-  }, []);
+  const [exportProgress, setExportProgress] = useState<{ current: number; total: number }>({ current: 0, total: 0 });
+  const { cameras, selectedCameraId, venue, projectVersion } = useStore();
 
   const capture2DCanvas = useCallback((): HTMLCanvasElement | null => {
     const capture = (window as any).__capture2DExport;
@@ -26,17 +33,14 @@ export default function ExportPanel() {
         return capture() as HTMLCanvasElement | null;
       } catch { /* fall through */ }
     }
-    // Fallback: grab DOM canvas
     return document.querySelector('.konvajs-content canvas') as HTMLCanvasElement | null;
   }, []);
 
   const capture3DCanvas = useCallback((): HTMLCanvasElement | null => {
-    // R3F renders to a canvas inside the 3D view container
     const canvases = document.querySelectorAll('canvas');
     for (const c of canvases) {
       if (c.closest('[data-venue3d]')) return c;
     }
-    // Fallback: find the WebGL canvas
     for (const c of canvases) {
       const ctx = c.getContext('webgl2') || c.getContext('webgl');
       if (ctx) return c;
@@ -44,216 +48,317 @@ export default function ExportPanel() {
     return null;
   }, []);
 
-  const generateExport = useCallback(async () => {
-    if (!cam) {
-      alert('Please select a camera first.');
+  const capturePreviewCanvas = useCallback((): HTMLCanvasElement | null => {
+    const fn = (window as any).__capturePreviewCanvas;
+    if (typeof fn === 'function') {
+      try { return fn() as HTMLCanvasElement | null; } catch { /* fall through */ }
+    }
+    return null;
+  }, []);
+
+  /** Wait two animation frames + a settle delay for Konva/R3F to paint at new dimensions. */
+  const waitForPaint = useCallback(async (settleMs = 250) => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        setTimeout(resolve, settleMs);
+      }));
+    });
+  }, []);
+
+  /** Render a single export PNG for a given camera + optional focal length override. */
+  const renderOne = useCallback(async (targetCam: VenueCamera, opts?: { focalOverride?: number; variantLabel?: string }) => {
+    const camDef = getCameraById(targetCam.cameraId, useStore.getState().customCameras);
+    const lensDef = getLensById(targetCam.lensId, useStore.getState().customLenses);
+    if (!camDef || !lensDef) return;
+
+    const focalLength = opts?.focalOverride ?? targetCam.focalLength;
+    const sensor = getEffectiveSensor(camDef, lensDef, targetCam.useSpeedbooster, targetCam.sensorModeIndex);
+    const adapterInfo = getAdapterInfo(camDef, lensDef, targetCam.useSpeedbooster);
+    const fov = computeFov(sensor, focalLength, targetCam.focusDistance, targetCam.extenderActive);
+    const dof = computeDof(sensor, focalLength, targetCam.aperture, targetCam.focusDistance, targetCam.extenderActive);
+    const personPx = personHeightInFrame(sensor.heightMm, focalLength * targetCam.extenderActive, targetCam.focusDistance);
+
+    // Apply override to the store so the live preview/2D/3D paint with the right state,
+    // then wait one frame so the canvases update before we capture them.
+    const originalFocal = targetCam.focalLength;
+    const originalSelected = useStore.getState().selectedCameraId;
+    const needSelectionChange = useStore.getState().selectedCameraId !== targetCam.id;
+    const needFocalChange = opts?.focalOverride !== undefined && opts.focalOverride !== originalFocal;
+
+    if (needSelectionChange) useStore.getState().selectCamera(targetCam.id);
+    if (needFocalChange) useStore.getState().updateCamera(targetCam.id, { focalLength });
+    if (needSelectionChange || needFocalChange) await waitForPaint();
+
+    // ── Layout constants ──
+    const EW = 1920;
+    const padding = 20;
+    const headerH = 80;
+    const tileW = (EW - padding * 3) / 2;
+    const tileH = Math.round(tileW * 9 / 16);
+    const calcH = 260;
+    const totalH = headerH + padding + tileH + padding + tileH + padding + calcH + padding;
+
+    const out = document.createElement('canvas');
+    out.width = EW;
+    out.height = totalH;
+    const ctx = out.getContext('2d')!;
+
+    ctx.fillStyle = '#0f1117';
+    ctx.fillRect(0, 0, EW, totalH);
+
+    // ── Header ──
+    ctx.fillStyle = '#1a1d27';
+    ctx.fillRect(0, 0, EW, headerH);
+    ctx.fillStyle = '#3b82f6';
+    ctx.font = 'bold 28px sans-serif';
+    ctx.textAlign = 'left';
+    const variant = opts?.variantLabel ? ` — ${opts.variantLabel}` : '';
+    ctx.fillText(`${targetCam.label}${variant} — ${camDef.manufacturer} ${camDef.model}`, padding, 36);
+    ctx.fillStyle = '#e5e7eb';
+    ctx.font = '16px sans-serif';
+    ctx.fillText(`Lens: ${lensDef.manufacturer} ${lensDef.model} @ ${focalLength.toFixed(1)}mm`, padding, 60);
+    ctx.textAlign = 'right';
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '14px sans-serif';
+    ctx.fillText(`${venue.name} — Project v${projectVersion} — MultiCam Planner v${APP_VERSION}`, EW - padding, 30);
+    ctx.fillText(`Exported: ${new Date().toLocaleString()}`, EW - padding, 50);
+    if (adapterInfo) {
+      ctx.fillStyle = '#f59e0b';
+      ctx.fillText(`Adapter: ${adapterInfo.name}`, EW - padding, 70);
+    }
+
+    // ── Tile helper: letterbox to preserve aspect ratio ──
+    function drawTile(srcCanvas: HTMLCanvasElement | null, x: number, y: number, label: string) {
+      ctx.fillStyle = '#0a0e14';
+      ctx.fillRect(x, y, tileW, tileH);
+
+      if (srcCanvas && srcCanvas.width > 0 && srcCanvas.height > 0) {
+        const srcRatio = srcCanvas.width / srcCanvas.height;
+        const tileRatio = tileW / tileH;
+        let dw: number, dh: number;
+        if (srcRatio > tileRatio) {
+          dw = tileW;
+          dh = tileW / srcRatio;
+        } else {
+          dh = tileH;
+          dw = tileH * srcRatio;
+        }
+        const dx = x + (tileW - dw) / 2;
+        const dy = y + (tileH - dh) / 2;
+        ctx.drawImage(srcCanvas, dx, dy, dw, dh);
+      } else {
+        ctx.fillStyle = '#1a1d27';
+        ctx.fillRect(x, y, tileW, tileH);
+        ctx.fillStyle = '#6b7280';
+        ctx.font = '14px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(`${label} — not available`, x + tileW / 2, y + tileH / 2);
+      }
+      ctx.strokeStyle = '#2a2d3a';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x, y, tileW, tileH);
+      ctx.fillStyle = '#000000aa';
+      ctx.fillRect(x, y, 160, 28);
+      ctx.fillStyle = '#e5e7eb';
+      ctx.font = 'bold 14px sans-serif';
+      ctx.textAlign = 'left';
+      ctx.fillText(label, x + 8, y + 19);
+    }
+
+    const plan2D = capture2DCanvas();
+    const view3D = capture3DCanvas();
+    const previewCanvas = capturePreviewCanvas();
+
+    drawTile(plan2D, padding, headerH + padding, '2D Plan');
+    drawTile(view3D, padding * 2 + tileW, headerH + padding, '3D View');
+    drawTile(previewCanvas, padding, headerH + padding + tileH + padding, 'Camera Preview');
+
+    // Calculator data tile
+    const calcX = padding * 2 + tileW;
+    const calcY = headerH + padding + tileH + padding;
+    ctx.fillStyle = '#1a1d27';
+    ctx.fillRect(calcX, calcY, tileW, tileH);
+    ctx.strokeStyle = '#2a2d3a';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(calcX, calcY, tileW, tileH);
+
+    ctx.fillStyle = '#000000aa';
+    ctx.fillRect(calcX, calcY, 200, 28);
+    ctx.fillStyle = '#e5e7eb';
+    ctx.font = 'bold 14px sans-serif';
+    ctx.textAlign = 'left';
+    ctx.fillText('Calculator / Data', calcX + 8, calcY + 19);
+
+    const cx = calcX + 20;
+    let cy = calcY + 50;
+    const lineH = 22;
+
+    ctx.font = 'bold 15px monospace';
+    ctx.fillStyle = '#3b82f6';
+    ctx.fillText('CAMERA & OPTICS', cx, cy); cy += lineH + 4;
+
+    ctx.font = '13px monospace';
+    ctx.fillStyle = '#e5e7eb';
+    const lines = [
+      `Camera:      ${camDef.manufacturer} ${camDef.model}`,
+      `Sensor:      ${sensor.name} (${sensor.widthMm.toFixed(1)}×${sensor.heightMm.toFixed(1)}mm, ×${sensor.cropFactor.toFixed(2)})`,
+      `Mount:       ${camDef.mount}`,
+      `Lens:        ${lensDef.manufacturer} ${lensDef.model}`,
+      `Focal Length: ${focalLength.toFixed(1)}mm${targetCam.extenderActive > 1 ? ` (×${targetCam.extenderActive} = ${(focalLength * targetCam.extenderActive).toFixed(0)}mm)` : ''}`,
+      `Aperture:    f/${targetCam.aperture}`,
+      `Focus Dist:  ${targetCam.focusDistance.toFixed(1)}m`,
+      `Position:    X=${targetCam.x.toFixed(1)}m Y=${targetCam.y.toFixed(1)}m Z=${targetCam.z.toFixed(1)}m`,
+      `Pan: ${targetCam.pan.toFixed(1)}°  Tilt: ${targetCam.tilt.toFixed(1)}°`,
+      '',
+      `FOV H:       ${fov.horizontalDeg.toFixed(2)}°`,
+      `FOV V:       ${fov.verticalDeg.toFixed(2)}°`,
+      `Image:       ${fov.imageWidthAtDistance.toFixed(2)}m × ${fov.imageHeightAtDistance.toFixed(2)}m`,
+      `35mm eq FL:  ${fov.equivalentFocalLength.toFixed(0)}mm`,
+      `DoF:         ${dof.nearLimit < 0.01 ? '0' : dof.nearLimit.toFixed(2)}m – ${dof.farLimit === Infinity ? '∞' : dof.farLimit.toFixed(2) + 'm'}`,
+      `Hyperfocal:  ${dof.hyperfocal.toFixed(2)}m`,
+      `Person 1.8m: ${personPx.toFixed(0)}px / 1080 (${((personPx / 1080) * 100).toFixed(1)}%)`,
+    ];
+    if (adapterInfo) {
+      const lossStr = adapterInfo.lightLossStops > 0 ? `−${adapterInfo.lightLossStops}T` : adapterInfo.lightLossStops < 0 ? `+${Math.abs(adapterInfo.lightLossStops)}T` : '0T';
+      lines.push(`Adapter:     ${adapterInfo.name} (${lossStr})`);
+    }
+
+    lines.forEach((line) => {
+      if (line === '') { cy += 6; return; }
+      if (line.startsWith('FOV') || line.startsWith('DoF') || line.startsWith('Person')) {
+        ctx.fillStyle = '#22c55e';
+      } else if (line.startsWith('Adapter')) {
+        ctx.fillStyle = '#f59e0b';
+      } else {
+        ctx.fillStyle = '#e5e7eb';
+      }
+      ctx.fillText(line, cx, cy);
+      cy += lineH;
+    });
+
+    // ── Camera list summary ──
+    const summaryY = headerH + padding + tileH + padding + tileH + padding;
+    ctx.fillStyle = '#1a1d27';
+    ctx.fillRect(padding, summaryY, EW - padding * 2, calcH);
+    ctx.strokeStyle = '#2a2d3a';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(padding, summaryY, EW - padding * 2, calcH);
+
+    ctx.fillStyle = '#3b82f6';
+    ctx.font = 'bold 15px monospace';
+    ctx.fillText('ALL CAMERAS IN PROJECT', padding + 16, summaryY + 24);
+
+    ctx.font = '12px monospace';
+    const colW = (EW - padding * 2 - 32) / 3;
+    let row = 0;
+    let col = 0;
+    cameras.forEach((c) => {
+      const cd = getCameraById(c.cameraId, useStore.getState().customCameras);
+      const ld = getLensById(c.lensId, useStore.getState().customLenses);
+      if (!cd || !ld) return;
+      const sx = padding + 16 + col * colW;
+      const sy = summaryY + 46 + row * 18;
+      const isSelected = c.id === targetCam.id;
+      ctx.fillStyle = isSelected ? '#3b82f6' : '#9ca3af';
+      ctx.font = isSelected ? 'bold 12px monospace' : '12px monospace';
+      ctx.fillText(`${c.label}: ${cd.manufacturer} ${cd.model} + ${ld.model.substring(0, 30)}`, sx, sy);
+      col++;
+      if (col >= 3) { col = 0; row++; }
+    });
+
+    // ── Download ──
+    const filename = `${targetCam.label.replace(/\s+/g, '_')}${opts?.variantLabel ? `_${opts.variantLabel.replace(/\s+/g, '_')}` : ''}_${venue.name.replace(/[^a-zA-Z0-9_-]/g, '_')}_v${projectVersion}.png`;
+    await new Promise<void>((resolve) => {
+      out.toBlob((blob) => {
+        if (!blob) { resolve(); return; }
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+        resolve();
+      }, 'image/png');
+    });
+
+    // ── Restore overrides ──
+    if (needFocalChange) useStore.getState().updateCamera(targetCam.id, { focalLength: originalFocal });
+    if (needSelectionChange) useStore.getState().selectCamera(originalSelected);
+  }, [cameras, venue, projectVersion, capture2DCanvas, capture3DCanvas, capturePreviewCanvas, waitForPaint]);
+
+  const generateExport = useCallback(async (mode: ExportMode = 'current') => {
+    const state = useStore.getState();
+    const currentCam = state.cameras.find((c) => c.id === state.selectedCameraId);
+    const targetCams = (mode === 'all' || mode === 'all-widetele')
+      ? state.cameras
+      : currentCam ? [currentCam] : [];
+
+    if (targetCams.length === 0) {
+      alert('No cameras to export. Add a camera first.');
       return;
     }
 
     setExporting(true);
 
-    try {
-      const camDef = getCameraById(cam.cameraId);
-      const lensDef = getLensById(cam.lensId, useStore.getState().customLenses);
-      if (!camDef || !lensDef) return;
-
-      const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster);
-      const adapterInfo = getAdapterInfo(camDef, lensDef, cam.useSpeedbooster);
-      const fov = computeFov(sensor, cam.focalLength, cam.focusDistance, cam.extenderActive);
-      const dof = computeDof(sensor, cam.focalLength, cam.aperture, cam.focusDistance, cam.extenderActive);
-      const personPx = personHeightInFrame(sensor.heightMm, cam.focalLength * cam.extenderActive, cam.focusDistance);
-
-      // ── Layout constants ──
-      const EW = 1920; // export width
-      const padding = 20;
-      const headerH = 80;
-      const tileW = (EW - padding * 3) / 2;
-      const tileH = Math.round(tileW * 9 / 16);
-      const calcH = 260;
-      const totalH = headerH + padding + tileH + padding + tileH + padding + calcH + padding;
-
-      const out = document.createElement('canvas');
-      out.width = EW;
-      out.height = totalH;
-      const ctx = out.getContext('2d')!;
-
-      // Background
-      ctx.fillStyle = '#0f1117';
-      ctx.fillRect(0, 0, EW, totalH);
-
-      // ── Header ──
-      ctx.fillStyle = '#1a1d27';
-      ctx.fillRect(0, 0, EW, headerH);
-      ctx.fillStyle = '#3b82f6';
-      ctx.font = 'bold 28px sans-serif';
-      ctx.textAlign = 'left';
-      ctx.fillText(`${cam.label} — ${camDef.manufacturer} ${camDef.model}`, padding, 36);
-      ctx.fillStyle = '#e5e7eb';
-      ctx.font = '16px sans-serif';
-      ctx.fillText(`Lens: ${lensDef.manufacturer} ${lensDef.model}`, padding, 60);
-      // Right side: project info
-      ctx.textAlign = 'right';
-      ctx.fillStyle = '#9ca3af';
-      ctx.font = '14px sans-serif';
-      ctx.fillText(`${venue.name} — Project v${projectVersion} — MultiCam Planner v${APP_VERSION}`, EW - padding, 30);
-      ctx.fillText(`Exported: ${new Date().toLocaleString()}`, EW - padding, 50);
-      if (adapterInfo) {
-        ctx.fillStyle = '#f59e0b';
-        ctx.fillText(`Adapter: ${adapterInfo.name}`, EW - padding, 70);
-      }
-
-      // ── Tile helper ──
-      function drawTile(srcCanvas: HTMLCanvasElement | null, x: number, y: number, label: string) {
-        // Border
-        ctx.strokeStyle = '#2a2d3a';
-        ctx.lineWidth = 2;
-        ctx.strokeRect(x, y, tileW, tileH);
-
-        if (srcCanvas && srcCanvas.width > 0 && srcCanvas.height > 0) {
-          ctx.drawImage(srcCanvas, x, y, tileW, tileH);
-        } else {
-          ctx.fillStyle = '#1a1d27';
-          ctx.fillRect(x, y, tileW, tileH);
-          ctx.fillStyle = '#6b7280';
-          ctx.font = '14px sans-serif';
-          ctx.textAlign = 'center';
-          ctx.fillText(`${label} — not available`, x + tileW / 2, y + tileH / 2);
-        }
-        // Label
-        ctx.fillStyle = '#000000aa';
-        ctx.fillRect(x, y, 160, 28);
-        ctx.fillStyle = '#e5e7eb';
-        ctx.font = 'bold 14px sans-serif';
-        ctx.textAlign = 'left';
-        ctx.fillText(label, x + 8, y + 19);
-      }
-
-      // ── Capture views ──
-      const plan2D = capture2DCanvas();
-      const view3D = capture3DCanvas();
-      const previewCanvas = typeof (window as any).__capturePreviewCanvas === 'function'
-        ? (window as any).__capturePreviewCanvas()
-        : captureCanvas('canvas[width="640"]');
-
-      // Row 1: 2D Plan + 3D View
-      drawTile(plan2D, padding, headerH + padding, '2D Plan');
-      drawTile(view3D, padding * 2 + tileW, headerH + padding, '3D View');
-
-      // Row 2: Preview + Calculator data
-      drawTile(previewCanvas, padding, headerH + padding + tileH + padding, 'Camera Preview');
-
-      // Calculator data tile (rendered as text)
-      const calcX = padding * 2 + tileW;
-      const calcY = headerH + padding + tileH + padding;
-      ctx.fillStyle = '#1a1d27';
-      ctx.fillRect(calcX, calcY, tileW, tileH);
-      ctx.strokeStyle = '#2a2d3a';
-      ctx.lineWidth = 2;
-      ctx.strokeRect(calcX, calcY, tileW, tileH);
-
-      // Calculator label
-      ctx.fillStyle = '#000000aa';
-      ctx.fillRect(calcX, calcY, 200, 28);
-      ctx.fillStyle = '#e5e7eb';
-      ctx.font = 'bold 14px sans-serif';
-      ctx.textAlign = 'left';
-      ctx.fillText('Calculator / Data', calcX + 8, calcY + 19);
-
-      // Calculator content
-      const cx = calcX + 20;
-      let cy = calcY + 50;
-      const lineH = 22;
-
-      ctx.font = 'bold 15px monospace';
-      ctx.fillStyle = '#3b82f6';
-      ctx.fillText('CAMERA & OPTICS', cx, cy); cy += lineH + 4;
-
-      ctx.font = '13px monospace';
-      ctx.fillStyle = '#e5e7eb';
-      const lines = [
-        `Camera:      ${camDef.manufacturer} ${camDef.model}`,
-        `Sensor:      ${sensor.name} (${sensor.widthMm.toFixed(1)}×${sensor.heightMm.toFixed(1)}mm, ×${sensor.cropFactor.toFixed(2)})`,
-        `Mount:       ${camDef.mount}`,
-        `Lens:        ${lensDef.manufacturer} ${lensDef.model}`,
-        `Focal Length: ${cam.focalLength}mm${cam.extenderActive > 1 ? ` (×${cam.extenderActive} = ${(cam.focalLength * cam.extenderActive).toFixed(0)}mm)` : ''}`,
-        `Aperture:    f/${cam.aperture}`,
-        `Focus Dist:  ${cam.focusDistance.toFixed(1)}m`,
-        `Position:    X=${cam.x.toFixed(1)}m Y=${cam.y.toFixed(1)}m Z=${cam.z.toFixed(1)}m`,
-        `Pan: ${cam.pan.toFixed(1)}°  Tilt: ${cam.tilt.toFixed(1)}°`,
-        '',
-        `FOV H:       ${fov.horizontalDeg.toFixed(2)}°`,
-        `FOV V:       ${fov.verticalDeg.toFixed(2)}°`,
-        `Image:       ${fov.imageWidthAtDistance.toFixed(2)}m × ${fov.imageHeightAtDistance.toFixed(2)}m`,
-        `35mm eq FL:  ${fov.equivalentFocalLength.toFixed(0)}mm`,
-        `DoF:         ${dof.nearLimit < 0.01 ? '0' : dof.nearLimit.toFixed(2)}m – ${dof.farLimit === Infinity ? '∞' : dof.farLimit.toFixed(2) + 'm'}`,
-        `Hyperfocal:  ${dof.hyperfocal.toFixed(2)}m`,
-        `Person 1.8m: ${personPx.toFixed(0)}px / 1080 (${((personPx / 1080) * 100).toFixed(1)}%)`,
-      ];
-      if (adapterInfo) {
-        const lossStr = adapterInfo.lightLossStops > 0 ? `−${adapterInfo.lightLossStops}T` : adapterInfo.lightLossStops < 0 ? `+${Math.abs(adapterInfo.lightLossStops)}T` : '0T';
-        lines.push(`Adapter:     ${adapterInfo.name} (${lossStr})`);
-      }
-
-      lines.forEach((line) => {
-        if (line === '') { cy += 6; return; }
-        if (line.startsWith('FOV') || line.startsWith('DoF') || line.startsWith('Person')) {
-          ctx.fillStyle = '#22c55e';
-        } else if (line.startsWith('Adapter')) {
-          ctx.fillStyle = '#f59e0b';
-        } else {
-          ctx.fillStyle = '#e5e7eb';
-        }
-        ctx.fillText(line, cx, cy);
-        cy += lineH;
-      });
-
-      // ── Camera list summary at bottom ──
-      const summaryY = headerH + padding + tileH + padding + tileH + padding;
-      ctx.fillStyle = '#1a1d27';
-      ctx.fillRect(padding, summaryY, EW - padding * 2, calcH);
-      ctx.strokeStyle = '#2a2d3a';
-      ctx.lineWidth = 2;
-      ctx.strokeRect(padding, summaryY, EW - padding * 2, calcH);
-
-      ctx.fillStyle = '#3b82f6';
-      ctx.font = 'bold 15px monospace';
-      ctx.fillText('ALL CAMERAS IN PROJECT', padding + 16, summaryY + 24);
-
-      ctx.font = '12px monospace';
-      const colW = (EW - padding * 2 - 32) / 3;
-      let row = 0;
-      let col = 0;
-      cameras.forEach((c, i) => {
-        const cd = getCameraById(c.cameraId);
-        const ld = getLensById(c.lensId, useStore.getState().customLenses);
-        if (!cd || !ld) return;
-        const sx = padding + 16 + col * colW;
-        const sy = summaryY + 46 + row * 18;
-        const isSelected = c.id === cam.id;
-        ctx.fillStyle = isSelected ? '#3b82f6' : '#9ca3af';
-        ctx.font = isSelected ? 'bold 12px monospace' : '12px monospace';
-        ctx.fillText(`${c.label}: ${cd.manufacturer} ${cd.model} + ${ld.model.substring(0, 30)}`, sx, sy);
-        col++;
-        if (col >= 3) { col = 0; row++; }
-      });
-
-      // ── Download ──
-      out.toBlob((blob) => {
-        if (!blob) return;
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${cam.label.replace(/\s+/g, '_')}_${venue.name.replace(/[^a-zA-Z0-9_-]/g, '_')}_v${projectVersion}.png`;
-        a.click();
-        URL.revokeObjectURL(url);
-      }, 'image/png');
-    } finally {
-      setExporting(false);
+    // Prepare layout (force Grid so all panels render at proper size)
+    let restoreLayout: (() => void) | null = null;
+    const prepFn = (window as any).__multicamPrepareForExport as
+      | (() => Promise<{ restore: () => void } | null>)
+      | undefined;
+    if (typeof prepFn === 'function') {
+      try {
+        const prep = await prepFn();
+        if (prep) restoreLayout = prep.restore;
+      } catch { /* fall through */ }
     }
-  }, [cam, cameras, venue, projectVersion, capture2DCanvas, capture3DCanvas, captureCanvas, persons]);
+
+    const originalSelected = state.selectedCameraId;
+    const wantsWideTele = mode === 'widetele' || mode === 'all-widetele';
+
+    // Build the work queue
+    type Job = { cam: VenueCamera; focalOverride?: number; variantLabel?: string };
+    const jobs: Job[] = [];
+    for (const tc of targetCams) {
+      if (wantsWideTele) {
+        const lens = getLensById(tc.lensId, useStore.getState().customLenses);
+        if (!lens) { jobs.push({ cam: tc }); continue; }
+        if (lens.focalLengthMin === lens.focalLengthMax) {
+          // Prime — just one export
+          jobs.push({ cam: tc, variantLabel: `${lens.focalLengthMin}mm` });
+        } else {
+          jobs.push({ cam: tc, focalOverride: lens.focalLengthMin, variantLabel: `wide_${lens.focalLengthMin}mm` });
+          jobs.push({ cam: tc, focalOverride: lens.focalLengthMax, variantLabel: `tele_${lens.focalLengthMax}mm` });
+        }
+      } else {
+        jobs.push({ cam: tc });
+      }
+    }
+
+    setExportProgress({ current: 0, total: jobs.length });
+
+    try {
+      for (let i = 0; i < jobs.length; i++) {
+        setExportProgress({ current: i + 1, total: jobs.length });
+        await renderOne(jobs[i].cam, {
+          focalOverride: jobs[i].focalOverride,
+          variantLabel: jobs[i].variantLabel,
+        });
+      }
+    } finally {
+      // Restore original selection (renderOne handles per-camera restore but final
+      // cleanup ensures we land on whatever was selected before the batch).
+      useStore.getState().selectCamera(originalSelected);
+      if (restoreLayout) restoreLayout();
+      setExporting(false);
+      setExportProgress({ current: 0, total: 0 });
+    }
+  }, [renderOne]);
 
   useEffect(() => {
-    const handler = () => generateExport();
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<ExportDetail>).detail;
+      generateExport(detail?.mode ?? 'current');
+    };
     window.addEventListener('multicam-export', handler);
     return () => window.removeEventListener('multicam-export', handler);
   }, [generateExport]);
@@ -261,8 +366,13 @@ export default function ExportPanel() {
   if (exporting) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-        <div className="bg-bc-panel rounded-lg p-6 text-white text-center">
-          <div className="animate-pulse mb-2">Generating export...</div>
+        <div className="bg-bc-panel rounded-lg p-6 text-white text-center min-w-[260px]">
+          <div className="animate-pulse mb-2">Generating export…</div>
+          {exportProgress.total > 1 && (
+            <div className="text-xs text-gray-400">
+              {exportProgress.current} / {exportProgress.total}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useStore, APP_VERSION } from '../../store/useStore';
 import { FiCamera, FiLayout, FiBox, FiMonitor, FiSliders, FiSave, FiUpload, FiDownload, FiChevronDown, FiX, FiCheck } from 'react-icons/fi';
 import { useRef, useCallback, useState, useEffect } from 'react';
+import type { ExportMode } from '../Export/ExportPanel';
 
 const tabs: { id: string; label: string; icon: React.ReactNode }[] = [
   { id: 'tab-2d', label: '2D Plan', icon: <FiLayout size={16} /> },
@@ -36,7 +37,9 @@ export default function Header({
   const [presetMenuOpen, setPresetMenuOpen] = useState(false);
   const [savePresetName, setSavePresetName] = useState('');
   const [showSaveInput, setShowSaveInput] = useState(false);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const presetMenuRef = useRef<HTMLDivElement>(null);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
   const saveInputRef = useRef<HTMLInputElement>(null);
 
   // Close preset menu on outside click
@@ -52,6 +55,18 @@ export default function Header({
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [presetMenuOpen]);
+
+  // Close export menu on outside click
+  useEffect(() => {
+    if (!exportMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
+        setExportMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [exportMenuOpen]);
 
   // Auto-focus the save input when shown
   useEffect(() => {
@@ -78,9 +93,9 @@ export default function Header({
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [loadProject]);
 
-  const handleExport = useCallback(async () => {
-    // Dispatch custom event that the ExportPanel will listen to
-    window.dispatchEvent(new CustomEvent('multicam-export'));
+  const handleExport = useCallback((mode: ExportMode = 'current') => {
+    setExportMenuOpen(false);
+    window.dispatchEvent(new CustomEvent('multicam-export', { detail: { mode } }));
   }, []);
 
   return (
@@ -224,10 +239,53 @@ export default function Header({
           <FiUpload size={14} />
           <span className="hidden sm:inline">Open</span>
         </button>
-        <button onClick={handleExport} className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-bc-accent hover:text-white hover:bg-bc-accent/20 transition-colors" title="Export all views as PNG">
-          <FiDownload size={14} />
-          <span className="hidden sm:inline">Export</span>
-        </button>
+        <div className="relative" ref={exportMenuRef}>
+          <button
+            onClick={() => setExportMenuOpen((o) => !o)}
+            className="flex items-center gap-1 px-2 py-1 rounded-md text-xs text-bc-accent hover:text-white hover:bg-bc-accent/20 transition-colors"
+            title="Export views as PNG"
+          >
+            <FiDownload size={14} />
+            <span className="hidden sm:inline">Export</span>
+            <FiChevronDown size={12} />
+          </button>
+          {exportMenuOpen && (
+            <div className="absolute right-0 top-full mt-2 min-w-[260px] rounded-lg border border-bc-border bg-bc-panel shadow-2xl overflow-hidden z-30">
+              <button
+                type="button"
+                onClick={() => handleExport('current')}
+                className="w-full text-left px-3 py-2 text-xs text-gray-200 hover:bg-bc-border hover:text-white transition-colors"
+              >
+                <div className="font-medium">Current camera</div>
+                <div className="text-[10px] text-gray-500">Selected camera at current focal length</div>
+              </button>
+              <button
+                type="button"
+                onClick={() => handleExport('all')}
+                className="w-full text-left px-3 py-2 text-xs text-gray-200 hover:bg-bc-border hover:text-white transition-colors border-t border-bc-border"
+              >
+                <div className="font-medium">All cameras</div>
+                <div className="text-[10px] text-gray-500">One PNG per camera at its current focal length</div>
+              </button>
+              <button
+                type="button"
+                onClick={() => handleExport('widetele')}
+                className="w-full text-left px-3 py-2 text-xs text-gray-200 hover:bg-bc-border hover:text-white transition-colors border-t border-bc-border"
+              >
+                <div className="font-medium">Current — wide + tele</div>
+                <div className="text-[10px] text-gray-500">Selected camera at lens min and max focal length</div>
+              </button>
+              <button
+                type="button"
+                onClick={() => handleExport('all-widetele')}
+                className="w-full text-left px-3 py-2 text-xs text-gray-200 hover:bg-bc-border hover:text-white transition-colors border-t border-bc-border"
+              >
+                <div className="font-medium">All — wide + tele</div>
+                <div className="text-[10px] text-gray-500">Two PNGs per camera (lens min and max)</div>
+              </button>
+            </div>
+          )}
+        </div>
         <input ref={fileInputRef} type="file" accept=".mcplan,.json" className="hidden" onChange={handleFileChange} />
         <span className="text-xs text-gray-500 hidden lg:inline">v{APP_VERSION}</span>
       </div>

--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -27,6 +27,10 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   const [showThirds, setShowThirds] = useState(false);
   const [showCrosshair, setShowCrosshair] = useState(true);
   const [showData, setShowData] = useState(true);
+  const [focusPickMode, setFocusPickMode] = useState(false);
+  // Cache projected person positions during draw() so the click handler can hit-test
+  // without re-projecting everything itself.
+  const projectedPersons = useRef<{ id: string; sx: number; sy: number; topSy: number; dist: number }[]>([]);
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -35,11 +39,11 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const camDef = getCameraById(cam.cameraId);
+    const camDef = getCameraById(cam.cameraId, useStore.getState().customCameras);
     const lensDef = getLensById(cam.lensId, useStore.getState().customLenses);
     if (!camDef || !lensDef) return;
 
-    const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster);
+    const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster, cam.sensorModeIndex);
 
     // HiDPI: size canvas to container at device pixel ratio
     const dpr = window.devicePixelRatio || 1;
@@ -116,28 +120,73 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       ctx.stroke();
     }
 
-    // ── Helper: world position to screen pixel ──
+    // ── Helpers: world ↔ camera-space ↔ screen ──
     const panRad = (cam.pan * Math.PI) / 180;
     const cosP = Math.cos(panRad);
     const sinP = Math.sin(panRad);
+    const fovHRad = (fov.horizontalDeg * Math.PI) / 360;
+    const fovVRad = (fov.verticalDeg * Math.PI) / 360;
+    const tiltRad = (cam.tilt * Math.PI) / 180;
+    const tiltShift = Math.tan(tiltRad);
+    const NEAR = 0.1;
 
-    const worldToScreen = (wx: number, wy: number, wz: number): { sx: number; sy: number; dist: number; behindCamera: boolean } => {
+    type CamPoint = { x: number; y: number; z: number };
+
+    const worldToCamera = (wx: number, wy: number, wz: number): CamPoint => {
       const c = cam!;
       const dx = wx - c.x;
       const dy = wy - c.y;
-      const localZ = dx * cosP + dy * sinP;
-      const localX = -dx * sinP + dy * cosP;
-      if (localZ <= 0.1) return { sx: -999, sy: -999, dist: 0, behindCamera: true };
-      const fovHRad = (fov.horizontalDeg * Math.PI) / 360;
-      const fovVRad = (fov.verticalDeg * Math.PI) / 360;
-      const screenX = W / 2 + (localX / (localZ * Math.tan(fovHRad))) * (W / 2);
-      const tiltRad = (c.tilt * Math.PI) / 180;
-      const apparentY = (wz - c.z) / localZ;
-      const tiltShift = Math.tan(tiltRad);
+      return {
+        x: -dx * sinP + dy * cosP,
+        y: wz - c.z,
+        z: dx * cosP + dy * sinP,
+      };
+    };
+
+    const cameraToScreen = (p: CamPoint) => {
+      const screenX = W / 2 + (p.x / (p.z * Math.tan(fovHRad))) * (W / 2);
+      const apparentY = p.y / p.z;
       // Positive tilt (look up) rotates the world DOWN in camera frame → subtract tiltShift
       // so that ground objects move toward the bottom of the screen as tilt increases.
       const screenY = H / 2 - ((apparentY - tiltShift) / Math.tan(fovVRad)) * (H / 2);
-      return { sx: screenX, sy: screenY, dist: localZ, behindCamera: false };
+      return { sx: screenX, sy: screenY, dist: p.z };
+    };
+
+    /** Sutherland–Hodgman polygon clipping against the near plane (z ≥ NEAR). */
+    const clipPolygonNear = (poly: CamPoint[]): CamPoint[] => {
+      const out: CamPoint[] = [];
+      for (let i = 0; i < poly.length; i++) {
+        const cur = poly[i];
+        const prev = poly[(i - 1 + poly.length) % poly.length];
+        const curIn = cur.z >= NEAR;
+        const prevIn = prev.z >= NEAR;
+        if (curIn) {
+          if (!prevIn) {
+            const t = (NEAR - prev.z) / (cur.z - prev.z);
+            out.push({
+              x: prev.x + t * (cur.x - prev.x),
+              y: prev.y + t * (cur.y - prev.y),
+              z: NEAR,
+            });
+          }
+          out.push(cur);
+        } else if (prevIn) {
+          const t = (NEAR - prev.z) / (cur.z - prev.z);
+          out.push({
+            x: prev.x + t * (cur.x - prev.x),
+            y: prev.y + t * (cur.y - prev.y),
+            z: NEAR,
+          });
+        }
+      }
+      return out;
+    };
+
+    const worldToScreen = (wx: number, wy: number, wz: number): { sx: number; sy: number; dist: number; behindCamera: boolean } => {
+      const camP = worldToCamera(wx, wy, wz);
+      if (camP.z <= NEAR) return { sx: -999, sy: -999, dist: 0, behindCamera: true };
+      const s = cameraToScreen(camP);
+      return { sx: s.sx, sy: s.sy, dist: s.dist, behindCamera: false };
     };
     const worldToScreenLocal = worldToScreen;
 
@@ -178,25 +227,28 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
     }
 
     // ── Draw stages from venue ──
+    // Build the polygon in camera-space, then clip against the near plane so corners
+    // behind the camera become near-plane intersection points instead of being skipped
+    // (which previously turned the rectangle into a degenerate triangle).
     venue.stages.forEach((stage) => {
-      const corners = [
-        { x: stage.x, y: stage.y, z: 0 },
-        { x: stage.x + stage.width, y: stage.y, z: 0 },
-        { x: stage.x + stage.width, y: stage.y + stage.height, z: 0 },
-        { x: stage.x, y: stage.y + stage.height, z: 0 },
+      const camCorners = [
+        worldToCamera(stage.x, stage.y, 0),
+        worldToCamera(stage.x + stage.width, stage.y, 0),
+        worldToCamera(stage.x + stage.width, stage.y + stage.height, 0),
+        worldToCamera(stage.x, stage.y + stage.height, 0),
       ];
-      const projected = corners.map((c) => worldToScreen(c.x, c.y, c.z));
-      if (projected.every((p) => p.behindCamera)) return;
+      const clipped = clipPolygonNear(camCorners);
+      if (clipped.length < 3) return;
+
+      const projected = clipped.map((p) => cameraToScreen(p));
 
       ctx.strokeStyle = '#3b82f6aa';
       ctx.fillStyle = '#3b82f622';
       ctx.lineWidth = 2;
       ctx.beginPath();
-      const validPts = projected.filter((p) => !p.behindCamera);
-      if (validPts.length < 2) return;
       ctx.moveTo(projected[0].sx, projected[0].sy);
       for (let i = 1; i < projected.length; i++) {
-        if (!projected[i].behindCamera) ctx.lineTo(projected[i].sx, projected[i].sy);
+        ctx.lineTo(projected[i].sx, projected[i].sy);
       }
       ctx.closePath();
       ctx.fill();
@@ -403,6 +455,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       }
     }
 
+    projectedPersons.current = [];
     persons.forEach((person) => {
       const feet = worldToScreen(person.x, person.y, 0);
       const head = worldToScreen(person.x, person.y, person.height);
@@ -422,6 +475,15 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       if (feetSx - objW > W) return;
       if (feetSy < 0 && headSy < 0) return;
       if (feetSy > H && headSy > H) return;
+
+      // Remember on-screen position for click-to-focus hit-testing
+      projectedPersons.current.push({
+        id: person.id,
+        sx: feetSx,
+        sy: feetSy,
+        topSy: headSy,
+        dist: feet.dist,
+      });
 
       drawPerson(feetSx, feetSy, headSy, feet.dist, person.objectType, `${person.label} (${person.height.toFixed(1)}m)`);
     });
@@ -611,28 +673,80 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   }, []);
 
   // ── PTZ Mouse Controls ──
+  const dragStart = useRef({ x: 0, y: 0 });
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     isDragging.current = true;
     lastMouse.current = { x: e.clientX, y: e.clientY };
-    (e.target as HTMLElement).style.cursor = 'grabbing';
-  }, []);
+    dragStart.current = { x: e.clientX, y: e.clientY };
+    (e.target as HTMLElement).style.cursor = focusPickMode ? 'crosshair' : 'grabbing';
+  }, [focusPickMode]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     if (!isDragging.current || !cam) return;
+    // In focus-pick mode the press is a click target — don't pan/tilt
+    if (focusPickMode) return;
     const dx = e.clientX - lastMouse.current.x;
     const dy = e.clientY - lastMouse.current.y;
     lastMouse.current = { x: e.clientX, y: e.clientY };
-    const panSens = 0.3;
-    const tiltSens = 0.2;
+
+    // FOV-scaled sensitivity so the scene moves 1:1 with the mouse: 1 px of cursor
+    // motion rotates the camera by exactly the angle that one pixel on the canvas
+    // spans. This keeps fine framing tractable at tight focal lengths and avoids
+    // sluggish dragging at wide angles.
+    const canvas = canvasRef.current;
+    const camDef = getCameraById(cam.cameraId, useStore.getState().customCameras);
+    const lensDef = getLensById(cam.lensId, useStore.getState().customLenses);
+    let panSens = 0.3;
+    let tiltSens = 0.2;
+    if (canvas && camDef && lensDef) {
+      const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster, cam.sensorModeIndex);
+      const fov = computeFov(sensor, cam.focalLength, cam.focusDistance, cam.extenderActive);
+      const cssW = canvas.clientWidth || canvas.width;
+      const cssH = canvas.clientHeight || canvas.height;
+      if (cssW > 0) panSens = fov.horizontalDeg / cssW;
+      if (cssH > 0) tiltSens = fov.verticalDeg / cssH;
+    }
     const newPan = Math.max(-180, Math.min(180, cam.pan - dx * panSens));
     const newTilt = Math.max(-90, Math.min(45, cam.tilt + dy * tiltSens));
     useStore.getState().updateCamera(cam.id, { pan: newPan, tilt: newTilt });
-  }, [cam]);
+  }, [cam, focusPickMode]);
 
   const handleMouseUp = useCallback((e: React.MouseEvent) => {
+    const wasDragging = isDragging.current;
     isDragging.current = false;
-    (e.target as HTMLElement).style.cursor = 'grab';
-  }, []);
+    (e.target as HTMLElement).style.cursor = focusPickMode ? 'crosshair' : 'grab';
+
+    if (!wasDragging || !cam) return;
+    const movedPx = Math.hypot(e.clientX - dragStart.current.x, e.clientY - dragStart.current.y);
+    if (!focusPickMode || movedPx > 4) return;
+
+    // ── Click-to-focus: hit-test against projected persons ──
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+
+    let best: { id: string; dist: number; pickDist: number } | null = null;
+    for (const p of projectedPersons.current) {
+      // Treat each person as a vertical bar of ~half its height in width
+      const personPxH = Math.abs(p.topSy - p.sy);
+      const halfW = Math.max(8, personPxH * 0.25);
+      const top = Math.min(p.topSy, p.sy);
+      const bottom = Math.max(p.topSy, p.sy);
+      // Allow generous vertical slop so labels/heads are easy to grab
+      const inX = cx >= p.sx - halfW && cx <= p.sx + halfW;
+      const inY = cy >= top - 8 && cy <= bottom + 12;
+      if (!inX || !inY) continue;
+      const cxDist = Math.abs(cx - p.sx);
+      if (!best || cxDist < best.pickDist) {
+        best = { id: p.id, dist: p.dist, pickDist: cxDist };
+      }
+    }
+    if (best) {
+      useStore.getState().updateCamera(cam.id, { focusDistance: Math.max(0.1, best.dist) });
+    }
+  }, [cam, focusPickMode]);
 
   const handleWheel = useCallback((e: React.WheelEvent) => {
     if (!cam) return;
@@ -654,9 +768,9 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   }
 
   // Computed data for readout (outside canvas)
-  const camDef = getCameraById(cam.cameraId);
+  const camDef = getCameraById(cam.cameraId, useStore.getState().customCameras);
   const lensDef = getLensById(cam.lensId, useStore.getState().customLenses);
-  const sensor = camDef && lensDef ? getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster) : undefined;
+  const sensor = camDef && lensDef ? getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster, cam.sensorModeIndex) : undefined;
   const adapterInfo = camDef && lensDef ? getAdapterInfo(camDef, lensDef, cam.useSpeedbooster) : null;
   const fov = sensor ? computeFov(sensor, cam.focalLength, cam.focusDistance, cam.extenderActive) : null;
   const dof = sensor ? computeDof(sensor, cam.focalLength, cam.aperture, cam.focusDistance, cam.extenderActive) : null;
@@ -681,7 +795,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
           <canvas
             ref={canvasRef}
             className="w-full rounded-lg"
-            style={{ cursor: 'grab', display: 'block' }}
+            style={{ cursor: focusPickMode ? 'crosshair' : 'grab', display: 'block' }}
             onMouseDown={handleMouseDown}
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
@@ -707,6 +821,13 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
               {label}
             </button>
           ))}
+          <button
+            onClick={() => setFocusPickMode((v) => !v)}
+            title={focusPickMode ? 'Click anywhere to leave focus-pick mode' : 'Pick a person in the preview to set focus distance'}
+            className={`px-2 py-0.5 rounded text-[10px] font-medium border transition-colors ${focusPickMode ? 'border-bc-yellow text-bc-yellow bg-bc-yellow/10' : 'border-bc-border text-gray-500 hover:text-gray-300'}`}
+          >
+            ◎ Focus pick {focusPickMode ? '· ON' : ''}
+          </button>
           {!undocked && (
             <button
               onClick={onUndock}
@@ -716,7 +837,9 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
               <FiExternalLink size={10} /> Float
             </button>
           )}
-          <span className="text-[10px] text-gray-600 ml-auto">Drag: Pan/Tilt · Scroll: Zoom</span>
+          <span className="text-[10px] text-gray-600 ml-auto">
+            {focusPickMode ? 'Click a person to set focus distance' : 'Drag: Pan/Tilt · Scroll: Zoom'}
+          </span>
         </div>
 
         {/* Zoom slider */}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,8 +1,8 @@
 import { useStore } from '../../store/useStore';
-import { CAMERAS, getCameraById, getAdapterInfo, getEffectiveSensor } from '../../data/cameras';
+import { CAMERAS, SENSORS, getCameraById, getAdapterInfo, getEffectiveSensor } from '../../data/cameras';
 import { LENSES, getLensById, getCompatibleLenses } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
-import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar } from 'react-icons/fi';
+import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiCamera } from 'react-icons/fi';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { BackgroundPlan, StageObjectType, CameraMountType } from '../../types';
 import { MOUNT_TYPE_LABELS } from '../../types';
@@ -54,7 +54,8 @@ function CameraCard({ camId }: { camId: string }) {
   const [showNewLens, setShowNewLens] = useState(false);
   const [newLens, setNewLens] = useState({ manufacturer: '', model: '', focalMin: '10', focalMax: '100', aperture: '2.8', mount: 'B4', type: 'zoom' as 'zoom' | 'prime' });
 
-  const camDef = getCameraById(cam.cameraId);
+  const { customCameras } = useStore();
+  const camDef = getCameraById(cam.cameraId, customCameras);
   const lensDef = getLensById(cam.lensId) ?? customLenses.find((l) => l.id === cam.lensId);
   const allLenses = [...LENSES, ...customLenses];
   const compatLenses = camDef ? getCompatibleLenses(camDef.mount, camDef.adaptedMounts) : allLenses;
@@ -66,11 +67,12 @@ function CameraCard({ camId }: { camId: string }) {
   // Deduplicate by id
   const compatDeduped = [...new Map(allCompat.map((l) => [l.id, l])).values()];
   const grouped = groupByMount(sortFavoritesFirst(compatDeduped, favoriteLensIds));
-  const sortedCameras = sortFavoritesFirst(CAMERAS, favoriteCameraIds);
+  const sortedCameras = sortFavoritesFirst([...CAMERAS, ...customCameras], favoriteCameraIds);
+  const isCustomCamera = (id: string) => customCameras.some((c) => c.id === id);
 
   // Adapter & effective sensor
   const adapterInfo = camDef && lensDef ? getAdapterInfo(camDef, lensDef, cam.useSpeedbooster) : null;
-  const effectiveSensor = camDef && lensDef ? getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster) : camDef?.sensor;
+  const effectiveSensor = camDef && lensDef ? getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster, cam.sensorModeIndex) : camDef?.sensor;
   const fov = effectiveSensor && lensDef ? computeFov(effectiveSensor, cam.focalLength, cam.focusDistance, cam.extenderActive) : null;
   const dof = effectiveSensor && lensDef ? computeDof(effectiveSensor, cam.focalLength, cam.aperture, cam.focusDistance, cam.extenderActive) : null;
 
@@ -155,7 +157,7 @@ function CameraCard({ camId }: { camId: string }) {
               className="block w-full mt-0.5 bg-bc-dark border border-bc-border rounded px-2 py-1 text-white"
               value={cam.cameraId}
               onChange={(e) => {
-                const newCam = getCameraById(e.target.value);
+                const newCam = getCameraById(e.target.value, customCameras);
                 if (!newCam) return;
                 const lens = getCompatibleLenses(newCam.mount, newCam.adaptedMounts)[0];
                 const supportsExtender = cam.extenderActive === 1 || !!lens?.extenderFactors?.includes(cam.extenderActive);
@@ -167,14 +169,39 @@ function CameraCard({ camId }: { camId: string }) {
                   extenderActive: supportsExtender ? cam.extenderActive : 1,
                   // Speedbooster only valid on MFT cameras with EF lenses
                   useSpeedbooster: newCam.mount === 'MFT' && lens?.mount === 'EF' ? cam.useSpeedbooster : false,
+                  // Reset hardware sensor mode — each body has a different mode list
+                  sensorModeIndex: newCam.sensorModes && newCam.sensorModes.length > 0 ? 0 : undefined,
                 });
               }}
             >
               {sortedCameras.map((c) => (
-                <option key={c.id} value={c.id}>{favoriteCameraIds.includes(c.id) ? '* ' : ''}{c.manufacturer} {c.model} [{c.mount}]</option>
+                <option key={c.id} value={c.id}>{favoriteCameraIds.includes(c.id) ? '* ' : ''}{c.manufacturer} {c.model} [{c.mount}]{isCustomCamera(c.id) ? ' +custom' : ''}</option>
               ))}
             </select>
           </label>
+
+          {/* Hardware sensor mode (URSA B4 crop, VENICE windows, FX9 S35 etc.) */}
+          {camDef?.sensorModes && camDef.sensorModes.length > 1 && (
+            <label className="block">
+              <span className="text-gray-400">Sensor Mode</span>
+              <select
+                className="block w-full mt-0.5 bg-bc-dark border border-bc-border rounded px-2 py-1 text-white"
+                value={cam.sensorModeIndex ?? 0}
+                onChange={(e) => updateCamera(cam.id, { sensorModeIndex: parseInt(e.target.value) })}
+                disabled={!!adapterInfo?.cropSensor}
+                title={adapterInfo?.cropSensor ? 'Adapter crop overrides the sensor mode' : 'Pick the camera body crop mode'}
+              >
+                {camDef.sensorModes.map((mode, idx) => (
+                  <option key={idx} value={idx}>{mode.name}</option>
+                ))}
+              </select>
+              {adapterInfo?.cropSensor && (
+                <span className="text-[10px] text-bc-yellow">
+                  Adapter forces {adapterInfo.cropSensor.name}
+                </span>
+              )}
+            </label>
+          )}
 
           {/* Lens selector grouped by mount */}
           <label className="block">
@@ -475,12 +502,25 @@ export default function Sidebar() {
     persons, addPerson, addStageObject, removePerson, updatePerson,
     backgroundPlan, setBackgroundPlan,
     walls, addWall, removeWall, updateWall,
+    customCameras, addCustomCamera, removeCustomCamera,
   } = useStore();
   const [venueOpen, setVenueOpen] = useState(false);
   const [stagesOpen, setStagesOpen] = useState(false);
   const [personsOpen, setPersonsOpen] = useState(false);
   const [wallsOpen, setWallsOpen] = useState(false);
   const [bgOpen, setBgOpen] = useState(false);
+  const [customCamsOpen, setCustomCamsOpen] = useState(false);
+  const [showAddCustomCam, setShowAddCustomCam] = useState(false);
+  const [newCustomCam, setNewCustomCam] = useState({
+    manufacturer: '',
+    model: '',
+    mount: 'EF',
+    type: 'cinema' as 'broadcast' | 'cinema' | 'ptz' | 'mirrorless' | 'camcorder' | 'eng',
+    sensorKey: 'S35',
+    sensorW: '',
+    sensorH: '',
+    sensorName: '',
+  });
   const [wallDrawMode, setWallDrawMode] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [calibAxis, setCalibAxis] = useState<'x' | 'y' | null>(null);
@@ -924,6 +964,179 @@ export default function Sidebar() {
                   Remove Background
                 </button>
               </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Custom camera library */}
+      <div className="p-3 border-b border-bc-border">
+        <button
+          className="flex items-center justify-between w-full text-sm text-white font-semibold"
+          onClick={() => setCustomCamsOpen(!customCamsOpen)}
+        >
+          <span><FiCamera className="inline mr-1" size={13} />Custom Cameras ({customCameras.length})</span>
+          {customCamsOpen ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
+        </button>
+        {customCamsOpen && (
+          <div className="mt-2 space-y-2 text-xs">
+            {customCameras.length === 0 && !showAddCustomCam && (
+              <p className="text-gray-500 text-[10px]">No custom cameras. Add a body for non-listed gear.</p>
+            )}
+            {customCameras.map((c) => (
+              <div key={c.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
+                <span className="text-white text-xs flex-1 truncate">{c.manufacturer} {c.model}</span>
+                <span className="text-gray-500 text-[10px]">{c.mount}</span>
+                <button
+                  onClick={() => {
+                    if (cameras.some((vc) => vc.cameraId === c.id)) {
+                      alert(`Cannot remove "${c.manufacturer} ${c.model}" — it is used by ${cameras.filter((vc) => vc.cameraId === c.id).length} placed camera(s). Remove those first.`);
+                      return;
+                    }
+                    removeCustomCamera(c.id);
+                  }}
+                  className="p-0.5 hover:text-bc-red"
+                  title="Remove custom camera"
+                >
+                  <FiTrash2 size={11} />
+                </button>
+              </div>
+            ))}
+            {showAddCustomCam ? (
+              <div className="bg-bc-dark rounded p-2 border border-bc-border space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-gray-300 font-medium text-[11px]">New Custom Camera</span>
+                  <button onClick={() => setShowAddCustomCam(false)} className="text-gray-500 hover:text-white text-xs">✕</button>
+                </div>
+                <div className="grid grid-cols-2 gap-1">
+                  <input
+                    placeholder="Manufacturer"
+                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                    value={newCustomCam.manufacturer}
+                    onChange={(e) => setNewCustomCam({ ...newCustomCam, manufacturer: e.target.value })}
+                  />
+                  <input
+                    placeholder="Model"
+                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                    value={newCustomCam.model}
+                    onChange={(e) => setNewCustomCam({ ...newCustomCam, model: e.target.value })}
+                  />
+                </div>
+                <label className="block">
+                  <span className="text-gray-500 text-[10px]">Sensor</span>
+                  <select
+                    className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                    value={newCustomCam.sensorKey}
+                    onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorKey: e.target.value })}
+                  >
+                    {Object.entries(SENSORS).map(([key, s]) => (
+                      <option key={key} value={key}>{s.name} ({s.widthMm}×{s.heightMm}mm)</option>
+                    ))}
+                    <option value="__custom__">Custom size…</option>
+                  </select>
+                </label>
+                {newCustomCam.sensorKey === '__custom__' && (
+                  <div className="grid grid-cols-3 gap-1">
+                    <input
+                      placeholder="Name"
+                      className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                      value={newCustomCam.sensorName}
+                      onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorName: e.target.value })}
+                    />
+                    <input
+                      type="number"
+                      step="0.01"
+                      placeholder="Width mm"
+                      className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                      value={newCustomCam.sensorW}
+                      onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorW: e.target.value })}
+                    />
+                    <input
+                      type="number"
+                      step="0.01"
+                      placeholder="Height mm"
+                      className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                      value={newCustomCam.sensorH}
+                      onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorH: e.target.value })}
+                    />
+                  </div>
+                )}
+                <div className="grid grid-cols-2 gap-1">
+                  <label>
+                    <span className="text-gray-500 text-[10px]">Mount</span>
+                    <select
+                      className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                      value={newCustomCam.mount}
+                      onChange={(e) => setNewCustomCam({ ...newCustomCam, mount: e.target.value })}
+                    >
+                      {['B4', 'EF', 'PL', 'E', 'MFT', 'RF', 'L', 'FZ', 'integrated', 'M12'].map((m) => (
+                        <option key={m} value={m}>{m}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    <span className="text-gray-500 text-[10px]">Type</span>
+                    <select
+                      className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                      value={newCustomCam.type}
+                      onChange={(e) => setNewCustomCam({ ...newCustomCam, type: e.target.value as typeof newCustomCam.type })}
+                    >
+                      <option value="broadcast">Broadcast</option>
+                      <option value="cinema">Cinema</option>
+                      <option value="ptz">PTZ</option>
+                      <option value="mirrorless">Mirrorless</option>
+                      <option value="camcorder">Camcorder</option>
+                      <option value="eng">ENG</option>
+                    </select>
+                  </label>
+                </div>
+                <button
+                  onClick={() => {
+                    if (!newCustomCam.manufacturer.trim() || !newCustomCam.model.trim()) return;
+                    let sensor;
+                    if (newCustomCam.sensorKey === '__custom__') {
+                      const w = parseFloat(newCustomCam.sensorW);
+                      const h = parseFloat(newCustomCam.sensorH);
+                      if (!w || !h) { alert('Enter sensor width and height in mm.'); return; }
+                      // Diagonal-based crop factor against 43.27mm full-frame diagonal
+                      const diag = Math.sqrt(w * w + h * h);
+                      const cropFactor = 43.267 / diag;
+                      sensor = {
+                        name: newCustomCam.sensorName.trim() || `${w}×${h}mm`,
+                        widthMm: w,
+                        heightMm: h,
+                        cropFactor,
+                      };
+                    } else {
+                      sensor = SENSORS[newCustomCam.sensorKey];
+                    }
+                    addCustomCamera({
+                      manufacturer: newCustomCam.manufacturer.trim(),
+                      model: newCustomCam.model.trim(),
+                      sensor,
+                      mount: newCustomCam.mount,
+                      resolutions: ['HD'],
+                      type: newCustomCam.type,
+                    });
+                    setNewCustomCam({
+                      manufacturer: '', model: '', mount: 'EF', type: 'cinema',
+                      sensorKey: 'S35', sensorW: '', sensorH: '', sensorName: '',
+                    });
+                    setShowAddCustomCam(false);
+                  }}
+                  disabled={!newCustomCam.manufacturer.trim() || !newCustomCam.model.trim()}
+                  className="flex items-center gap-1 px-2 py-1 rounded bg-bc-green/20 text-bc-green text-xs hover:bg-bc-green/30 w-full justify-center disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  <FiPlus size={12} /> Create custom camera
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowAddCustomCam(true)}
+                className="flex items-center gap-1 px-2 py-1 rounded bg-bc-accent/20 text-bc-accent text-xs hover:bg-bc-accent/30 w-full justify-center"
+              >
+                <FiPlus size={12} /> Add custom camera
+              </button>
             )}
           </div>
         )}

--- a/src/components/Venue2D/Venue2D.tsx
+++ b/src/components/Venue2D/Venue2D.tsx
@@ -396,11 +396,11 @@ export default function Venue2D() {
         {/* FOV cones (non-interactive, rendered first = behind everything) */}
         {cameras.map((cam) => {
           if (!showAllFov && cam.id !== selectedCameraId) return null;
-          const camDef = getCameraById(cam.cameraId);
+          const camDef = getCameraById(cam.cameraId, useStore.getState().customCameras);
           const lensDef = getLensById(cam.lensId, useStore.getState().customLenses);
           if (!camDef || !lensDef) return null;
 
-          const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster);
+          const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster, cam.sensorModeIndex);
           const fov = computeFov(sensor, cam.focalLength, cam.focusDistance, cam.extenderActive);
           const fovMin = computeFov(sensor, lensDef.focalLengthMax, cam.focusDistance, cam.extenderActive);
           const fovMax = computeFov(sensor, lensDef.focalLengthMin, cam.focusDistance, cam.extenderActive);

--- a/src/components/Venue3D/Venue3D.tsx
+++ b/src/components/Venue3D/Venue3D.tsx
@@ -299,11 +299,11 @@ function StageMesh({ x, y, w, h, label }: { x: number; y: number; w: number; h: 
 }
 
 function FovPyramid({ cam, isSelected }: { cam: ReturnType<typeof useStore.getState>['cameras'][0]; isSelected: boolean }) {
-  const camDef = getCameraById(cam.cameraId);
+  const camDef = getCameraById(cam.cameraId, useStore.getState().customCameras);
   const lensDef = getLensById(cam.lensId, useStore.getState().customLenses);
   if (!camDef || !lensDef) return null;
 
-  const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster);
+  const sensor = getEffectiveSensor(camDef, lensDef, cam.useSpeedbooster, cam.sensorModeIndex);
   const fov = computeFov(sensor, cam.focalLength, cam.focusDistance, cam.extenderActive);
   const fovMin = computeFov(sensor, lensDef.focalLengthMax, cam.focusDistance, cam.extenderActive);
   const fovMax = computeFov(sensor, lensDef.focalLengthMin, cam.focusDistance, cam.extenderActive);

--- a/src/data/cameras.ts
+++ b/src/data/cameras.ts
@@ -19,12 +19,20 @@ export const CAMERAS: Camera[] = [
   { id: 'sony-hdc-5500', manufacturer: 'Sony', model: 'HDC-5500', sensor: SENSORS.TWO_THIRD, mount: 'B4', resolutions: ['4K', 'HD'], type: 'broadcast' },
   { id: 'sony-hdc-f5500', manufacturer: 'Sony', model: 'HDC-F5500', sensor: SENSORS.S35, mount: 'PL', resolutions: ['4K', 'HD'], type: 'broadcast', notes: 'Super 35mm broadcast camera' },
   { id: 'sony-venice', manufacturer: 'Sony', model: 'VENICE', sensor: SENSORS.FF, mount: 'PL', adaptedMounts: ['E'], resolutions: ['6K', '4K', 'HD'], type: 'cinema', notes: 'Full-frame CineAlta, PL native, E-mount via supplied adapter' },
-  { id: 'sony-venice2', manufacturer: 'Sony', model: 'VENICE 2', sensor: { name: 'FF 8.6K (36.2×24.1)', widthMm: 36.2, heightMm: 24.1, cropFactor: 0.99 }, mount: 'PL', adaptedMounts: ['E'], resolutions: ['8.6K', '6K', '4K', 'HD'], type: 'cinema', notes: 'Dual base ISO 800/3200, PL native, E-mount adapter' },
+  { id: 'sony-venice2', manufacturer: 'Sony', model: 'VENICE 2', sensor: { name: 'FF 8.6K (36.2×24.1)', widthMm: 36.2, heightMm: 24.1, cropFactor: 0.99 }, mount: 'PL', adaptedMounts: ['E'], resolutions: ['8.6K', '6K', '4K', 'HD'], type: 'cinema', notes: 'Dual base ISO 800/3200, PL native, E-mount adapter', sensorModes: [
+    { name: 'FF 8.6K (36.2×24.1)', widthMm: 36.2, heightMm: 24.1, cropFactor: 0.99 },
+    { name: 'FF 6K 3:2 (35.9×24.0)', widthMm: 35.9, heightMm: 24.0, cropFactor: 1.0 },
+    { name: 'S35 5.8K (24.8×13.1)', widthMm: 24.8, heightMm: 13.1, cropFactor: 1.46 },
+    { name: 'S35 4K 4:3 (19.0×14.2)', widthMm: 19.0, heightMm: 14.2, cropFactor: 1.89 },
+  ] },
   { id: 'sony-pmw-f5', manufacturer: 'Sony', model: 'PMW-F5', sensor: SENSORS.S35, mount: 'FZ', adaptedMounts: ['PL', 'B4'], resolutions: ['4K', '2K', 'HD'], type: 'cinema', notes: 'FZ-mount native, PL via adapter, B4 via Sony LA-FZB1 (LAFZ-B1)' },
   { id: 'sony-pmw-f55', manufacturer: 'Sony', model: 'PMW-F55', sensor: SENSORS.S35, mount: 'FZ', adaptedMounts: ['PL', 'B4'], resolutions: ['4K', '2K', 'HD'], type: 'cinema', notes: 'FZ-mount native, PL via adapter, B4 via Sony LA-FZB1 (LAFZ-B1) with crop to 2/3" area' },
   { id: 'sony-fx6', manufacturer: 'Sony', model: 'FX6', sensor: SENSORS.FF, mount: 'E', resolutions: ['4K', 'HD'], type: 'cinema' },
   { id: 'sony-fx3', manufacturer: 'Sony', model: 'FX3', sensor: SENSORS.FF, mount: 'E', resolutions: ['4K', 'HD'], type: 'cinema' },
-  { id: 'sony-fx9', manufacturer: 'Sony', model: 'PXW-FX9', sensor: SENSORS.FF, mount: 'E', resolutions: ['6K', '4K', 'HD'], type: 'cinema' },
+  { id: 'sony-fx9', manufacturer: 'Sony', model: 'PXW-FX9', sensor: SENSORS.FF, mount: 'E', resolutions: ['6K', '4K', 'HD'], type: 'cinema', sensorModes: [
+    { name: 'Full Frame (35.7×18.8)', widthMm: 35.7, heightMm: 18.8, cropFactor: 1.0 },
+    { name: 'Super 35 crop (23.6×12.4)', widthMm: 23.6, heightMm: 12.4, cropFactor: 1.51 },
+  ] },
   { id: 'sony-fs7ii', manufacturer: 'Sony', model: 'PXW-FS7 II', sensor: SENSORS.S35, mount: 'E', resolutions: ['4K', 'HD'], type: 'cinema' },
   { id: 'sony-a7siii', manufacturer: 'Sony', model: 'A7S III', sensor: SENSORS.FF, mount: 'E', resolutions: ['4K', 'HD'], type: 'mirrorless' },
   { id: 'sony-a7iv', manufacturer: 'Sony', model: 'A7 IV', sensor: SENSORS.FF, mount: 'E', resolutions: ['4K', 'HD'], type: 'mirrorless' },
@@ -58,8 +66,17 @@ export const CAMERAS: Camera[] = [
   { id: 'pana-aw-ue40', manufacturer: 'Panasonic', model: 'AW-UE40', sensor: SENSORS.HALF_INCH, mount: 'integrated', resolutions: ['4K', 'HD'], type: 'ptz' },
 
   // ── Blackmagic Design ──
-  { id: 'bmd-ursa-broadcast-g2', manufacturer: 'Blackmagic', model: 'URSA Broadcast G2', sensor: { name: 'BMD 6K (23.1×12.99)', widthMm: 23.1, heightMm: 12.99, cropFactor: 1.56 }, mount: 'B4', adaptedMounts: ['EF', 'PL'], resolutions: ['6K', '4K', 'HD'], type: 'broadcast', notes: 'B4 native, EF/PL via adapter. Broadcast camera with cinema sensor.' },
-  { id: 'bmd-ursa-12k', manufacturer: 'Blackmagic', model: 'URSA Mini Pro 12K', sensor: SENSORS.S35, mount: 'PL', adaptedMounts: ['EF'], resolutions: ['12K', '8K', '4K'], type: 'cinema' },
+  { id: 'bmd-ursa-broadcast-g2', manufacturer: 'Blackmagic', model: 'URSA Broadcast G2', sensor: { name: 'BMD 6K (23.1×12.99)', widthMm: 23.1, heightMm: 12.99, cropFactor: 1.56 }, mount: 'B4', adaptedMounts: ['EF', 'PL'], resolutions: ['6K', '4K', 'HD'], type: 'broadcast', notes: 'B4 native, EF/PL via adapter. Broadcast camera with cinema sensor.', sensorModes: [
+    { name: '6K Full (23.1×12.99)', widthMm: 23.1, heightMm: 12.99, cropFactor: 1.56 },
+    { name: '4K UHD S16 crop (12.4×6.97)', widthMm: 12.4, heightMm: 6.97, cropFactor: 2.91 },
+    { name: '2/3" B4 crop (9.6×5.4)', widthMm: 9.6, heightMm: 5.4, cropFactor: 3.93 },
+  ] },
+  { id: 'bmd-ursa-12k', manufacturer: 'Blackmagic', model: 'URSA Mini Pro 12K', sensor: SENSORS.S35, mount: 'PL', adaptedMounts: ['EF'], resolutions: ['12K', '8K', '4K'], type: 'cinema', sensorModes: [
+    { name: '12K Full S35 (27.03×14.25)', widthMm: 27.03, heightMm: 14.25, cropFactor: 1.33 },
+    { name: '12K 8:1 Open Gate (27.03×19.04)', widthMm: 27.03, heightMm: 19.04, cropFactor: 1.30 },
+    { name: '8K S16 crop (18.0×9.5)', widthMm: 18.0, heightMm: 9.5, cropFactor: 2.0 },
+    { name: '6K S16 crop (13.5×7.13)', widthMm: 13.5, heightMm: 7.13, cropFactor: 2.66 },
+  ] },
   { id: 'bmd-ursa-g2', manufacturer: 'Blackmagic', model: 'URSA Mini Pro G2', sensor: SENSORS.S35, mount: 'PL', adaptedMounts: ['EF'], resolutions: ['4.6K', '4K', 'HD'], type: 'cinema' },
   { id: 'bmd-ursa-46k', manufacturer: 'Blackmagic', model: 'URSA Mini Pro 4.6K', sensor: SENSORS.S35, mount: 'PL', adaptedMounts: ['EF'], resolutions: ['4.6K', '4K', 'HD'], type: 'cinema' },
   { id: 'bmd-pocket6kpro', manufacturer: 'Blackmagic', model: 'Pocket Cinema 6K Pro', sensor: SENSORS.S35, mount: 'EF', resolutions: ['6K', '4K', 'HD'], type: 'cinema' },
@@ -81,7 +98,12 @@ export const CAMERAS: Camera[] = [
   { id: 'hitachi-sk-uhd7000', manufacturer: 'Hitachi', model: 'SK-UHD7000', sensor: SENSORS.TWO_THIRD, mount: 'B4', resolutions: ['4K', 'HD'], type: 'broadcast' },
 
   // ── ARRI ──
-  { id: 'arri-alexa-35', manufacturer: 'ARRI', model: 'ALEXA 35', sensor: { name: 'ARRI ALEV 4 (27.99×19.22)', widthMm: 27.99, heightMm: 19.22, cropFactor: 1.29 }, mount: 'PL', resolutions: ['4.6K', '4K', 'HD'], type: 'cinema' },
+  { id: 'arri-alexa-35', manufacturer: 'ARRI', model: 'ALEXA 35', sensor: { name: 'ARRI ALEV 4 (27.99×19.22)', widthMm: 27.99, heightMm: 19.22, cropFactor: 1.29 }, mount: 'PL', resolutions: ['4.6K', '4K', 'HD'], type: 'cinema', sensorModes: [
+    { name: '4.6K 3:2 Open Gate (27.99×19.22)', widthMm: 27.99, heightMm: 19.22, cropFactor: 1.29 },
+    { name: '4K 16:9 (24.88×13.99)', widthMm: 24.88, heightMm: 13.99, cropFactor: 1.45 },
+    { name: '4K 2:1 (27.99×13.99)', widthMm: 27.99, heightMm: 13.99, cropFactor: 1.29 },
+    { name: '4K S16 (12.42×7.0)', widthMm: 12.42, heightMm: 7.0, cropFactor: 2.91 },
+  ] },
   { id: 'arri-amira', manufacturer: 'ARRI', model: 'AMIRA', sensor: SENSORS.S35, mount: 'PL', resolutions: ['4K UHD', 'HD'], type: 'cinema' },
 
   // ── RED ──
@@ -91,8 +113,8 @@ export const CAMERAS: Camera[] = [
   { id: 'marshall-cv568', manufacturer: 'Marshall', model: 'CV568', sensor: { name: '1/1.8" (7.44×5.58)', widthMm: 7.44, heightMm: 5.58, cropFactor: 4.84 }, mount: 'M12', resolutions: ['4K', 'HD'], type: 'broadcast', notes: 'POV camera, global shutter' },
 ];
 
-export function getCameraById(id: string): Camera | undefined {
-  return CAMERAS.find((c) => c.id === id);
+export function getCameraById(id: string, customCameras?: Camera[]): Camera | undefined {
+  return CAMERAS.find((c) => c.id === id) ?? customCameras?.find((c) => c.id === id);
 }
 
 export function getCamerasByType(type: Camera['type']): Camera[] {
@@ -154,13 +176,23 @@ export function getAdapterInfo(camera: Camera, lens: Lens, useSpeedbooster = fal
 }
 
 /**
- * Get the effective sensor size, accounting for adapter crop.
- * B4 lenses always project 2/3" image circle regardless of camera sensor.
- * Speedbooster widens the effective sensor area.
+ * Get the effective sensor size, accounting for adapter crop and selected hardware mode.
+ * Priority (highest first):
+ *   1. Adapter crop (e.g. B4 relay forces 2/3", Speedbooster widens MFT)
+ *   2. Camera hardware sensor mode (URSA B4 crop, VENICE window, FX9 S35 etc.)
+ *   3. Camera default sensor
  */
-export function getEffectiveSensor(camera: Camera, lens: Lens, useSpeedbooster = false): SensorSize {
+export function getEffectiveSensor(camera: Camera, lens: Lens, useSpeedbooster = false, sensorModeIndex?: number): SensorSize {
   const adapter = getAdapterInfo(camera, lens, useSpeedbooster);
   if (adapter?.cropSensor) return adapter.cropSensor;
+  if (
+    sensorModeIndex !== undefined &&
+    sensorModeIndex >= 0 &&
+    camera.sensorModes &&
+    sensorModeIndex < camera.sensorModes.length
+  ) {
+    return camera.sensorModes[sensorModeIndex];
+  }
   return camera.sensor;
 }
 

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -4,7 +4,7 @@ import { CAMERAS, CAMERA_COLORS } from '../data/cameras';
 import { LENSES } from '../data/lenses';
 import { TEMPLATES } from '../data/templates';
 
-export const APP_VERSION = '0.3.0';
+export const APP_VERSION = '0.4.0';
 
 interface AppState {
   // Venue

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand';
-import type { VenueCamera, Venue, ViewTab, ReferencePerson, BackgroundPlan, Stage, ProjectFile, VenueTemplate, StageObjectType, Lens, Wall } from '../types';
+import type { VenueCamera, Venue, ViewTab, ReferencePerson, BackgroundPlan, Stage, ProjectFile, VenueTemplate, StageObjectType, Lens, Wall, Camera } from '../types';
 import { CAMERAS, CAMERA_COLORS } from '../data/cameras';
 import { LENSES } from '../data/lenses';
 import { TEMPLATES } from '../data/templates';
 
-export const APP_VERSION = '0.2.0';
+export const APP_VERSION = '0.3.0';
 
 interface AppState {
   // Venue
@@ -31,6 +31,12 @@ interface AppState {
   customLenses: Lens[];
   addCustomLens: (lens: Omit<Lens, 'id' | 'isCustom'>) => string;
   removeCustomLens: (id: string) => void;
+
+  // Custom cameras
+  customCameras: Camera[];
+  addCustomCamera: (camera: Omit<Camera, 'id'>) => string;
+  updateCustomCamera: (id: string, updates: Partial<Omit<Camera, 'id'>>) => void;
+  removeCustomCamera: (id: string) => void;
 
   // Cameras placed in venue
   cameras: VenueCamera[];
@@ -111,6 +117,17 @@ function loadCustomLenses(): Lens[] {
 }
 function saveCustomLensesStorage(lenses: Lens[]) {
   localStorage.setItem(CUSTOM_LENSES_KEY, JSON.stringify(lenses));
+}
+
+const CUSTOM_CAMERAS_KEY = 'multicam-custom-cameras';
+function loadCustomCameras(): Camera[] {
+  try {
+    const raw = localStorage.getItem(CUSTOM_CAMERAS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch { return []; }
+}
+function saveCustomCamerasStorage(cameras: Camera[]) {
+  localStorage.setItem(CUSTOM_CAMERAS_KEY, JSON.stringify(cameras));
 }
 
 const FAVORITE_CAMERAS_KEY = 'multicam-favorite-cameras';
@@ -265,6 +282,36 @@ export const useStore = create<AppState>((set, get) => ({
     });
   },
 
+  // ── Custom Cameras ──
+  customCameras: loadCustomCameras(),
+
+  addCustomCamera: (camera) => {
+    const id = `custom-cam-${Date.now()}`;
+    const full: Camera = { ...camera, id };
+    set((s) => {
+      const updated = [...s.customCameras, full];
+      saveCustomCamerasStorage(updated);
+      return { customCameras: updated, projectVersion: s.projectVersion + 1 };
+    });
+    return id;
+  },
+
+  updateCustomCamera: (id, updates) => {
+    set((s) => {
+      const updated = s.customCameras.map((c) => (c.id === id ? { ...c, ...updates } : c));
+      saveCustomCamerasStorage(updated);
+      return { customCameras: updated, projectVersion: s.projectVersion + 1 };
+    });
+  },
+
+  removeCustomCamera: (id) => {
+    set((s) => {
+      const updated = s.customCameras.filter((c) => c.id !== id);
+      saveCustomCamerasStorage(updated);
+      return { customCameras: updated, projectVersion: s.projectVersion + 1 };
+    });
+  },
+
   // ── Cameras ──
   cameras: [],
   favoriteCameraIds: loadFavoriteIds(FAVORITE_CAMERAS_KEY),
@@ -337,6 +384,7 @@ export const useStore = create<AppState>((set, get) => ({
         extenderActive: 1,
         useSpeedbooster: false,
         mountType: 'tripod',
+        sensorModeIndex: camDef.sensorModes && camDef.sensorModes.length > 0 ? 0 : undefined,
       };
       return { cameras: [...s.cameras, newCam], selectedCameraId: newCam.id, projectVersion: s.projectVersion + 1 };
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,13 @@ export interface Camera {
   resolutions: string[];
   type: 'broadcast' | 'cinema' | 'ptz' | 'mirrorless' | 'camcorder' | 'eng';
   notes?: string;
+  /**
+   * Optional list of selectable sensor crop modes the body can run in. The first
+   * entry is treated as the default and is interchangeable with `sensor`. Use this
+   * for cameras with hardware crop modes that aren't determined by the lens (e.g.
+   * URSA Broadcast B4 crop, VENICE 2 6K/4K windows, FX9 Super35 crop).
+   */
+  sensorModes?: SensorSize[];
 }
 
 // ── Adapter result ──
@@ -109,6 +116,11 @@ export interface VenueCamera {
   extenderActive: number; // 1 = none, 1.5, 2
   useSpeedbooster?: boolean; // EF Speedbooster on MFT cameras
   mountType?: CameraMountType;
+  /**
+   * Index into `Camera.sensorModes` selecting a hardware crop mode. Undefined or
+   * out-of-range falls back to the camera's default sensor.
+   */
+  sensorModeIndex?: number;
 }
 
 // ── Stage / target zone ──


### PR DESCRIPTION
## Release notes — v0.4.0

Behebung der verbleibenden offenen Issues + drei größere Feature-Erweiterungen. Alle 11 offenen GitHub-Issues sind mit diesem Branch adressiert und geschlossen.

### Fehlerbehebungen

- **#10 / #6** Bühnen-Polygon wird zum Dreieck, wenn Ecke hinter der Kamera. Echtes Frustum-Clipping (Sutherland–Hodgman gegen die Near-Plane in Camera-Space), statt Sentinel-Punkte zu ignorieren.
- **#12** Preview Pan/Tilt-Geschwindigkeit ist jetzt FOV-skaliert (1 Maus-Pixel ↔ 1 Bild-Pixel). Fein bei Tele, grob bei Weitwinkel — vorher konstant 0.3°/px.
- **#4** Export-Tiles benutzen Letterboxing, der 2D-Plan wird nicht mehr in 16:9 gestaucht.
- **#7** Export erzwingt temporär Grid-Layout damit nicht-sichtbare Panels (3D, Preview) zur Capture-Zeit gepaintet sind. Vorheriges Layout wird automatisch wiederhergestellt.

### Neue Features

- **#4** Multi-Camera + Wide/Tele-Export. Export-Button im Header ist jetzt ein Dropdown mit vier Modi:
  - *Current camera* — eine PNG
  - *All cameras* — eine PNG pro Kamera
  - *Current wide + tele* — Min und Max Brennweite der ausgewählten Kamera
  - *All wide + tele* — zwei PNGs pro Kamera
- **#13** Sensor-Mode-Auswahl pro Kamera. Bodies mit mehreren Hardware-Crop-Modi (URSA Broadcast G2 / 12K, VENICE 2, FX9, ALEXA 35) bekommen ein Sensor-Mode-Dropdown im Sidebar-Card. Adapter-Crops (B4-Relay) gehen weiterhin vor.
- **#8** Custom Cameras. Neue Sidebar-Sektion zum Anlegen eigener Kamera-Bodies mit Manufacturer/Model/Sensor (Preset oder mm-Maße mit Auto-Crop-Factor)/Mount/Type. Persistiert in localStorage. Löschen blockiert solange Body noch platziert ist.
- **#2** Click-to-Focus im Preview. Neuer "◎ Focus pick"-Toggle in der Overlay-Bar — Klick auf eine Person setzt `focusDistance` exakt auf die Distanz Kamera→Person.

### Aufgeräumt / geschlossen ohne Code-Änderung

- **#1** Grid-Toggle gab es bereits — Issue obsolet.
- **#3** Photorealistic-Modus wurde in einem früheren Commit entfernt.
- **#5** wurde bereits durch den Double-Tilt-Fix in PR #14 behoben.

### Tech / unter der Haube

- `worldToScreen` im Preview ist in `worldToCamera` + `cameraToScreen` aufgeteilt; Polygone können jetzt sauber in Camera-Space geclippt werden bevor sie projiziert werden.
- `Camera.sensorModes?: SensorSize[]` und `VenueCamera.sensorModeIndex?: number` neu im Typsystem. `getEffectiveSensor` berücksichtigt sie (Adapter > sensorModeIndex > default).
- Custom Cameras werden über `getCameraById(id, customCameras)` aufgelöst — alle Aufrufstellen aktualisiert.
- ExportPanel wartet zwei Animation-Frames + 250ms Settle nach jedem State-Wechsel (Layout-Mode, Selection, Focal Length) damit Konva/R3F repaintet bevor captured wird.

### Nach dem Merge

1. Tag `v0.4.0` auf master setzen
2. GitHub Release aus dem Tag erstellen (dieser PR-Body kann als Release-Notes übernommen werden)
3. Optional: `npm run dist:win` für die Windows-Installer-Artefakte

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr)_