### PR TITLE
ci: build win + macOS desktop apps on release publish

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,95 @@
+name: Build Desktop Apps
+
+# Triggers a fresh Windows + macOS build whenever a GitHub release is published.
+# Artifacts (NSIS installer, portable .exe, DMG, ZIP) are uploaded directly to
+# the release page so users don't need to run electron-builder locally.
+#
+# The same workflow can be triggered manually (workflow_dispatch) for testing;
+# in that case the binaries are kept as workflow artifacts instead of being
+# attached to a release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to attach artifacts to (leave blank for workflow artifacts only)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            script: dist:win
+            artifacts: |
+              release/*.exe
+              release/*.blockmap
+              release/latest.yml
+          - os: macos-latest
+            script: dist:mac
+            artifacts: |
+              release/*.dmg
+              release/*.zip
+              release/*.blockmap
+              release/latest-mac.yml
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build distributable
+        run: npm run ${{ matrix.script }}
+        env:
+          # Open-source project — no Apple / Authenticode signing certs available.
+          # Disable signing instead of failing the build; the artifact will trigger
+          # the usual SmartScreen / Gatekeeper warning on first launch, which the
+          # README explains how to dismiss.
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # Token is only needed if electron-builder publishes itself. We pass
+          # --publish never in the scripts, but the token is still useful for
+          # GitHub-aware update checks during the build.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attach artifacts to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.artifacts }}
+          fail_on_unmatched_files: false
+
+      - name: Attach artifacts to release (manual run with tag)
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: ${{ matrix.artifacts }}
+          fail_on_unmatched_files: false
+
+      - name: Upload as workflow artifacts (manual run without tag)
+        if: github.event_name == 'workflow_dispatch' && inputs.tag == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: multicam-planner-${{ matrix.os }}
+          path: ${{ matrix.artifacts }}
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -95,20 +95,29 @@ npm run desktop
 
 # Build Windows installer & portable
 npm run dist:win
+
+# Build macOS DMG + ZIP (x64 + arm64, must run on macOS)
+npm run dist:mac
 ```
+
+A GitHub Actions workflow (`.github/workflows/release-build.yml`) automatically
+builds Windows and macOS artifacts whenever a release is published and attaches
+the binaries (NSIS installer, portable .exe, DMG, ZIP) directly to the release
+page. It can also be triggered manually via the Actions tab for testing.
 
 ---
 
 ## 📜 Useful Scripts
 
-| Script             | Description                            |
-|--------------------|----------------------------------------|
-| npm run dev        | Start local Vite dev server            |
-| npm run build      | TypeScript check + production build    |
-| npm run desktop    | Launch Electron in dev mode            |
-| npm run dist:win   | Build Windows installer & portable     |
-| npm run preview    | Preview production build               |
-| npm run lint       | Run ESLint linter                      |
+| Script             | Description                                       |
+|--------------------|---------------------------------------------------|
+| npm run dev        | Start local Vite dev server                       |
+| npm run build      | TypeScript check + production build               |
+| npm run desktop    | Launch Electron in dev mode                       |
+| npm run dist:win   | Build Windows installer & portable                |
+| npm run dist:mac   | Build macOS DMG + ZIP (x64 + arm64, host = macOS) |
+| npm run preview    | Preview production build                          |
+| npm run lint       | Run ESLint linter                                 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "desktop": "electron .",
-    "dist:win": "npm run build && electron-builder --win nsis portable",
+    "dist:win": "npm run build && electron-builder --win --publish never",
+    "dist:mac": "npm run build && electron-builder --mac --x64 --arm64 --publish never",
     "preview": "vite preview",
     "lint": "eslint ."
   },
@@ -35,6 +36,28 @@
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true
+    },
+    "mac": {
+      "category": "public.app-category.video",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ]
+    },
+    "dmg": {
+      "writeUpdateInfo": false
     }
   },
   "dependencies": {


### PR DESCRIPTION
When a GitHub release is published, .github/workflows/release-build.yml runs in parallel on windows-latest and macos-latest:

- npm ci
- npm run dist:win  → NSIS installer + portable .exe (x64)
- npm run dist:mac  → DMG + ZIP (x64 + arm64, separate binaries)

Each runner uploads its artifacts back to the release page via softprops/action-gh-release@v2, so users can download installers directly without anyone running electron-builder locally.

The workflow also supports manual dispatch from the Actions tab: optionally pass a tag to attach binaries to an existing release, or leave it blank to keep them as 14-day workflow artifacts for testing.

Code signing is intentionally disabled (CSC_IDENTITY_AUTO_DISCOVERY = false) since the project has no Apple Developer or Authenticode cert — users get the usual SmartScreen/Gatekeeper warnings on first launch.

Adds dist:mac script and build.mac/build.dmg config to package.json.

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr