### PR TITLE
feat: replace mount type with height slider + per-camera notes field

### DIFF
--- a/src/components/Export/ExportPanel.tsx
+++ b/src/components/Export/ExportPanel.tsx
@@ -236,6 +236,54 @@ export default function ExportPanel() {
       cy += lineH;
     });
 
+    // ── Notes (only if filled) ──
+    const notes = (targetCam.notes ?? '').trim();
+    if (notes) {
+      cy += 8;
+      ctx.fillStyle = '#3b82f6';
+      ctx.font = 'bold 13px monospace';
+      ctx.fillText('NOTES', cx, cy);
+      cy += lineH;
+
+      ctx.font = '12px monospace';
+      ctx.fillStyle = '#e5e7eb';
+      const noteMaxW = tileW - 40; // matches cx padding on both sides
+      const noteLineH = 16;
+
+      // Word-wrap inside the calc tile, respecting hard newlines in the user's text
+      const wrap = (text: string): string[] => {
+        const out: string[] = [];
+        for (const rawLine of text.split('\n')) {
+          if (!rawLine) { out.push(''); continue; }
+          const words = rawLine.split(/\s+/);
+          let cur = '';
+          for (const w of words) {
+            const test = cur ? `${cur} ${w}` : w;
+            if (ctx.measureText(test).width > noteMaxW && cur) {
+              out.push(cur);
+              cur = w;
+            } else {
+              cur = test;
+            }
+          }
+          if (cur) out.push(cur);
+        }
+        return out;
+      };
+
+      const tileBottom = calcY + tileH - 8;
+      const wrappedLines = wrap(notes);
+      for (const line of wrappedLines) {
+        if (cy > tileBottom) {
+          ctx.fillStyle = '#6b7280';
+          ctx.fillText('…', cx, cy);
+          break;
+        }
+        ctx.fillText(line, cx, cy);
+        cy += noteLineH;
+      }
+    }
+
     // ── Camera list summary ──
     const summaryY = headerH + padding + tileH + padding + tileH + padding;
     ctx.fillStyle = '#1a1d27';

--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -4,9 +4,7 @@ import { getLensById } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
 import { useRef, useEffect, useCallback, useState } from 'react';
 import type { StageObjectType } from '../../types';
-import { FiChevronDown, FiChevronUp, FiExternalLink, FiChevronLeft, FiChevronRight } from 'react-icons/fi';
-import { MOUNT_TYPE_LABELS } from '../../types';
-import type { CameraMountType } from '../../types';
+import { FiExternalLink, FiChevronLeft, FiChevronRight } from 'react-icons/fi';
 
 interface PreviewProps {
   undocked: boolean;
@@ -867,11 +865,18 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
             <div className="text-gray-500 text-[10px]">{camDef.sensor.name} · {camDef.mount}</div>
             <div className="text-gray-400 text-[10px] mt-0.5">{camDef.manufacturer} {camDef.model}</div>
             <div className="text-gray-400 text-[10px]">{lensDef.manufacturer} {lensDef.model}</div>
-            <div className="text-gray-500 text-[10px] mt-0.5">{MOUNT_TYPE_LABELS[(cam.mountType ?? 'tripod') as CameraMountType]}</div>
             {adapterInfo && (
               <div className="text-yellow-400 text-[10px] mt-0.5">⚡ {adapterInfo.name}{lightLoss}</div>
             )}
           </div>
+
+          {/* Notes — only when filled */}
+          {cam.notes && cam.notes.trim() && (
+            <div className="bg-bc-dark rounded-lg border border-bc-border p-2">
+              <div className="text-[10px] text-gray-500 leading-tight mb-0.5">Notes</div>
+              <div className="text-[11px] text-gray-200 whitespace-pre-wrap leading-snug">{cam.notes}</div>
+            </div>
+          )}
 
           {/* Data cells */}
           <DataCell label="Focal Length" value={`${cam.focalLength.toFixed(1)}mm`} sub={cam.extenderActive > 1 ? `eff. ${(cam.focalLength * cam.extenderActive).toFixed(0)}mm` : `eq. ${fov.equivalentFocalLength.toFixed(0)}mm`} />

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -4,8 +4,7 @@ import { LENSES, getLensById, getCompatibleLenses } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
 import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiCamera } from 'react-icons/fi';
 import { useState, useRef, useCallback, useEffect } from 'react';
-import type { BackgroundPlan, StageObjectType, CameraMountType } from '../../types';
-import { MOUNT_TYPE_LABELS } from '../../types';
+import type { BackgroundPlan, StageObjectType } from '../../types';
 import * as pdfjsLib from 'pdfjs-dist';
 
 /** Group lenses by mount for the dropdown */
@@ -421,8 +420,8 @@ function CameraCard({ camId }: { camId: string }) {
             </label>
           )}
 
-          {/* Position */}
-          <div className="grid grid-cols-3 gap-2">
+          {/* Position X / Y */}
+          <div className="grid grid-cols-2 gap-2">
             <label>
               <span className="text-gray-400">X (m)</span>
               <input
@@ -430,7 +429,7 @@ function CameraCard({ camId }: { camId: string }) {
                 className="w-full bg-bc-dark border border-bc-border rounded px-2 py-1 text-white"
                 value={cam.x}
                 step={0.5}
-                onChange={(e) => updateCamera(cam.id, { x: parseFloat(e.target.value) })}
+                onChange={(e) => updateCamera(cam.id, { x: parseFloat(e.target.value) || 0 })}
               />
             </label>
             <label>
@@ -440,33 +439,45 @@ function CameraCard({ camId }: { camId: string }) {
                 className="w-full bg-bc-dark border border-bc-border rounded px-2 py-1 text-white"
                 value={cam.y}
                 step={0.5}
-                onChange={(e) => updateCamera(cam.id, { y: parseFloat(e.target.value) })}
-              />
-            </label>
-            <label>
-              <span className="text-gray-400">Z (m)</span>
-              <input
-                type="number"
-                className="w-full bg-bc-dark border border-bc-border rounded px-2 py-1 text-white"
-                value={cam.z}
-                step={0.1}
-                onChange={(e) => updateCamera(cam.id, { z: parseFloat(e.target.value) })}
+                onChange={(e) => updateCamera(cam.id, { y: parseFloat(e.target.value) || 0 })}
               />
             </label>
           </div>
 
-          {/* Mount / Support type */}
+          {/* Camera height (Z) — slider for quick rough placement plus number input for precision */}
           <label className="block">
-            <span className="text-gray-400">Mount Type</span>
-            <select
-              className="block w-full mt-0.5 bg-bc-dark border border-bc-border rounded px-2 py-1 text-white"
-              value={cam.mountType ?? 'tripod'}
-              onChange={(e) => updateCamera(cam.id, { mountType: e.target.value as CameraMountType })}
-            >
-              {Object.entries(MOUNT_TYPE_LABELS).map(([k, v]) => (
-                <option key={k} value={k}>{v}</option>
-              ))}
-            </select>
+            <span className="text-gray-400">Height: {cam.z.toFixed(2)}m</span>
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                className="flex-1 accent-bc-accent"
+                min={0}
+                max={20}
+                step={0.05}
+                value={Math.min(20, Math.max(0, cam.z))}
+                onChange={(e) => updateCamera(cam.id, { z: parseFloat(e.target.value) })}
+              />
+              <input
+                type="number"
+                className="w-16 bg-bc-dark border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+                value={cam.z}
+                step={0.1}
+                min={0}
+                onChange={(e) => updateCamera(cam.id, { z: Math.max(0, parseFloat(e.target.value) || 0) })}
+              />
+            </div>
+          </label>
+
+          {/* Notes — free-form, shown in export when filled */}
+          <label className="block">
+            <span className="text-gray-400">Notes</span>
+            <textarea
+              className="block w-full mt-0.5 bg-bc-dark border border-bc-border rounded px-2 py-1 text-white text-xs resize-y min-h-[2.5rem]"
+              rows={2}
+              placeholder="Mount, operator, shot notes…"
+              value={cam.notes ?? ''}
+              onChange={(e) => updateCamera(cam.id, { notes: e.target.value })}
+            />
           </label>
 
           {/* DoF readout */}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -383,7 +383,6 @@ export const useStore = create<AppState>((set, get) => ({
         color: CAMERA_COLORS[idx % CAMERA_COLORS.length],
         extenderActive: 1,
         useSpeedbooster: false,
-        mountType: 'tripod',
         sensorModeIndex: camDef.sensorModes && camDef.sensorModes.length > 0 ? 0 : undefined,
       };
       return { cameras: [...s.cameras, newCam], selectedCameraId: newCam.id, projectVersion: s.projectVersion + 1 };
@@ -565,7 +564,11 @@ export const useStore = create<AppState>((set, get) => ({
     stageId = 1;
     personId = 1;
     // Re-assign IDs to avoid conflicts
-    const cameras = project.cameras.map((c) => ({ ...c, id: uid(), useSpeedbooster: c.useSpeedbooster ?? false, mountType: (c as any).mountType ?? 'tripod' }));
+    // Drop the deprecated mountType field if present in older project files
+    const cameras = project.cameras.map((c) => {
+      const { mountType: _drop, ...rest } = c as VenueCamera & { mountType?: string };
+      return { ...rest, id: uid(), useSpeedbooster: rest.useSpeedbooster ?? false };
+    });
     // Migrate old single-scale background plans to scaleX/scaleY
     let bgPlan = project.backgroundPlan;
     if (bgPlan && 'scale' in bgPlan && !('scaleX' in bgPlan)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,19 +52,6 @@ export interface Lens {
 // ── Object type presets ──
 export type StageObjectType = 'person' | 'person-guitar' | 'drums' | 'keys' | 'mic-stand' | 'custom';
 
-// ── Camera mount/support type ──
-export type CameraMountType = 'tripod' | 'pedestal' | 'jib' | 'dolly' | 'gimbal' | 'handheld' | 'steadicam' | 'fixed';
-
-export const MOUNT_TYPE_LABELS: Record<CameraMountType, string> = {
-  tripod: 'Stativ',
-  pedestal: 'Studio Pedestal',
-  jib: 'Jib / Crane',
-  dolly: 'Dolly',
-  gimbal: 'Gimbal',
-  handheld: 'Handheld',
-  steadicam: 'Steadicam',
-  fixed: 'Fixed Mount',
-};
 
 // ── Venue wall ──
 export interface Wall {
@@ -115,12 +102,16 @@ export interface VenueCamera {
   color: string;
   extenderActive: number; // 1 = none, 1.5, 2
   useSpeedbooster?: boolean; // EF Speedbooster on MFT cameras
-  mountType?: CameraMountType;
   /**
    * Index into `Camera.sensorModes` selecting a hardware crop mode. Undefined or
    * out-of-range falls back to the camera's default sensor.
    */
   sensorModeIndex?: number;
+  /**
+   * Free-form notes for this camera placement (mount, operator, instructions,
+   * shot list, etc.). Shown in the sidebar and included in PNG exports when set.
+   */
+  notes?: string;
 }
 
 // ── Stage / target zone ──


### PR DESCRIPTION
The mount type selector (tripod / pedestal / jib / dolly / gimbal / handheld / steadicam / fixed) was decorative — none of it affected geometry, calculations, or rendering. Removed:
- CameraMountType + MOUNT_TYPE_LABELS from types
- VenueCamera.mountType field
- mountType default in addCamera
- mountType migration on project load (now strips it instead)
- Mount-type selector in the sidebar
- Mount-type line in the preview data panel

In its place, two pieces of actually useful per-camera state:

1. Height slider. The Z field used to be a small number input wedged into the X/Y/Z grid. It's now a full-width range slider (0–20m, 0.05m step) with a paired number input for precision. Quick rough placement on the slider, exact values via the number field.

2. Notes textarea. Free-form per-camera notes (mount, operator, shot list, instructions, etc.). When filled:
   - Shown in the preview's right-hand data panel under the camera/lens header.
   - Shown in the PNG export inside the Calculator/Data tile under a "NOTES" heading, with word-wrapped text that respects the user's hard newlines and is truncated with "…" if it overflows the tile.

VenueCamera now has notes?: string. Empty/whitespace-only notes are treated as absent (nothing rendered in preview or export).

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr