### PR TITLE
fix: 3D export tile empty on first capture; auto-frame venue for export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -394,10 +394,13 @@ export default function App() {
         setLayoutMode('grid');
         // Wait long enough for FlexLayout to mount the new tabsets, for
         // ResizeObservers to fire on each panel container, and for Konva/R3F to
-        // paint at least one frame at the new dimensions.
+        // paint at least one frame at the new dimensions. R3F in particular needs
+        // multiple paint cycles after a fresh resize before its WebGL drawing
+        // buffer holds the visible scene — bumping to ~700ms avoids the first
+        // capture coming out as an empty/black 3D tile.
         await new Promise<void>((resolve) => {
           requestAnimationFrame(() => requestAnimationFrame(() => {
-            setTimeout(resolve, 250);
+            setTimeout(resolve, 700);
           }));
         });
       }

--- a/src/components/Export/ExportPanel.tsx
+++ b/src/components/Export/ExportPanel.tsx
@@ -66,7 +66,7 @@ export default function ExportPanel() {
   }, []);
 
   /** Render a single export PNG for a given camera + optional focal length override. */
-  const renderOne = useCallback(async (targetCam: VenueCamera, opts?: { focalOverride?: number; variantLabel?: string }) => {
+  const renderOne = useCallback(async (targetCam: VenueCamera, opts?: { focalOverride?: number; variantLabel?: string; extraSettleMs?: number }) => {
     const camDef = getCameraById(targetCam.cameraId, useStore.getState().customCameras);
     const lensDef = getLensById(targetCam.lensId, useStore.getState().customLenses);
     if (!camDef || !lensDef) return;
@@ -87,7 +87,8 @@ export default function ExportPanel() {
 
     if (needSelectionChange) useStore.getState().selectCamera(targetCam.id);
     if (needFocalChange) useStore.getState().updateCamera(targetCam.id, { focalLength });
-    if (needSelectionChange || needFocalChange) await waitForPaint();
+    const extra = opts?.extraSettleMs ?? 0;
+    if (needSelectionChange || needFocalChange || extra > 0) await waitForPaint(250 + extra);
 
     // ── Layout constants ──
     const EW = 1920;
@@ -360,6 +361,23 @@ export default function ExportPanel() {
       } catch { /* fall through */ }
     }
 
+    // Frame the 3D view on the venue so the exported tile shows the whole stage
+    // area instead of whatever free-fly angle the user happened to leave it on.
+    // The previous camera state is saved and restored after the batch.
+    const framingApi = (window as any).__multicam3DFraming as
+      | { save: () => any; apply: (s: any) => void; fitVenue: (w: number, h: number) => void }
+      | undefined;
+    let savedFraming: any = null;
+    if (framingApi) {
+      try {
+        savedFraming = framingApi.save();
+        framingApi.fitVenue(state.venue.widthM, state.venue.heightM);
+        // Allow the framing change to render — the WebGL drawing buffer needs at
+        // least one paint at the new camera before the capture has visible content.
+        await waitForPaint(500);
+      } catch { savedFraming = null; }
+    }
+
     const originalSelected = state.selectedCameraId;
     const wantsWideTele = mode === 'widetele' || mode === 'all-widetele';
 
@@ -390,12 +408,19 @@ export default function ExportPanel() {
         await renderOne(jobs[i].cam, {
           focalOverride: jobs[i].focalOverride,
           variantLabel: jobs[i].variantLabel,
+          // The first capture in the batch needs extra settle time so the WebGL
+          // 3D canvas, freshly resized by the layout swap and the framing change,
+          // actually paints visible content before drawImage reads from it.
+          extraSettleMs: i === 0 ? 400 : 0,
         });
       }
     } finally {
       // Restore original selection (renderOne handles per-camera restore but final
       // cleanup ensures we land on whatever was selected before the batch).
       useStore.getState().selectCamera(originalSelected);
+      if (framingApi && savedFraming) {
+        try { framingApi.apply(savedFraming); } catch { /* ignore */ }
+      }
       if (restoreLayout) restoreLayout();
       setExporting(false);
       setExportProgress({ current: 0, total: 0 });

--- a/src/components/Venue3D/Venue3D.tsx
+++ b/src/components/Venue3D/Venue3D.tsx
@@ -172,6 +172,43 @@ function FPSControls({ mouseLookEnabled }: { mouseLookEnabled: boolean }) {
     return () => window.removeEventListener('multicam-3d-reset', handleReset);
   }, [camera]);
 
+  // Expose a framing API for the export panel: save the current camera, frame the
+  // entire venue with a downward angle that fits the canvas, and restore later.
+  useEffect(() => {
+    (window as any).__multicam3DFraming = {
+      save: () => ({
+        pos: camera.position.toArray() as [number, number, number],
+        yaw: yaw.current,
+        pitch: pitch.current,
+      }),
+      apply: (state: { pos: [number, number, number]; yaw: number; pitch: number }) => {
+        camera.position.fromArray(state.pos);
+        yaw.current = state.yaw;
+        pitch.current = state.pitch;
+      },
+      fitVenue: (widthM: number, heightM: number) => {
+        // Position the camera above-behind the venue and aim at the floor centre.
+        // The result is a 3/4 overview where the whole stage area is visible
+        // even with the canvas constrained to the export tile's 16:9 ratio.
+        const diag = Math.sqrt(widthM * widthM + heightM * heightM);
+        const camX = widthM / 2;
+        const camY = diag * 0.55;
+        const camZ = heightM + diag * 0.4;
+        const targetX = widthM / 2;
+        const targetY = 0;
+        const targetZ = heightM / 2;
+        const dx = targetX - camX;
+        const dy = targetY - camY;
+        const dz = targetZ - camZ;
+        const horizDist = Math.sqrt(dx * dx + dz * dz);
+        camera.position.set(camX, camY, camZ);
+        yaw.current = Math.atan2(-dx, -dz);
+        pitch.current = Math.atan2(dy, horizDist);
+      },
+    };
+    return () => { delete (window as any).__multicam3DFraming; };
+  }, [camera]);
+
   useEffect(() => {
     const canvas = gl.domElement;
 


### PR DESCRIPTION
Two distinct issues observed in the multi-camera wide/tele export PNGs:

1. The first PNG in a batch (e.g. the wide variant) came out with a completely empty 3D tile, while later PNGs in the same batch had 3D content. The cause was paint timing — after FlexLayout swapped from Focus to Grid mode, the 3D Canvas was just being resized and R3F's WebGL drawing buffer hadn't painted at the new dimensions by the time the first drawImage ran. With preserveDrawingBuffer on, drawImage read a 0×0 or blank buffer.

   Fix: bump the post-layout-swap settle from 250 ms to 700 ms, and give the first iteration of the export loop an extra 400 ms on top of the per-iteration waitForPaint. By the time anyone reaches the wide capture there have been ~3 paint cycles at the final size.

2. The 3D tile framed the venue from whatever free-fly position the user happened to leave the FPS controls on. The default view sits far behind the venue with only a ~20° downward tilt, so on a small stage the venue ends up tiny in the upper third of the tile and the bottom 60% is empty floor.

   Fix: expose a window.__multicam3DFraming API from FPSControls with save / apply / fitVenue methods. fitVenue positions the camera diagonally above-behind the venue and computes yaw/pitch so it aims exactly at the floor centre — works for any venue width × depth. ExportPanel saves the user's current camera, calls fitVenue before the loop, and restores it in finally so the user's free-fly position is preserved across the export.

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr