### PR TITLE
ci: sync package.json version with release tag before building

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -57,6 +57,31 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Sync package.json version with the release tag
+        # electron-builder names artifacts (e.g. "MultiCam Planner Setup X.Y.Z.exe")
+        # using the version field in package.json — NOT the git tag. Without this
+        # step a release tagged v0.4.1 still produces "Setup 0.4.0.exe" if the
+        # last committed package.json was 0.4.0.
+        #
+        # Resolves the version source in this priority order:
+        #   1. release event              → github.event.release.tag_name
+        #   2. workflow_dispatch with tag → inputs.tag
+        #   3. workflow_dispatch w/o tag  → keep package.json as-is (manual test)
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RAW="${{ github.event.release.tag_name }}"
+          else
+            RAW="${{ inputs.tag }}"
+          fi
+          if [ -n "$RAW" ]; then
+            VERSION="${RAW#v}"
+            echo "Setting package.json version to $VERSION (from tag $RAW)"
+            npm version "$VERSION" --no-git-tag-version --allow-same-version
+          else
+            echo "No tag supplied — keeping package.json version $(node -p "require('./package.json').version")"
+          fi
+
       - name: Build distributable
         run: npm run ${{ matrix.script }}
         env:


### PR DESCRIPTION
electron-builder reads the version from package.json and bakes it into every artifact name — "MultiCam Planner Setup X.Y.Z.exe", "MultiCam Planner-X.Y.Z-arm64.dmg", etc. The git tag has no effect on this. As a result a release tagged v0.4.1 still produced "Setup 0.4.0.exe" because package.json on master was last bumped to 0.4.0.

The release-build workflow now runs `npm version <tag>` between `npm ci` and the dist build, with --no-git-tag-version so it just patches package.json in the runner's checkout without trying to commit or tag anything.

Resolution order for the version string:
  1. release event              → github.event.release.tag_name
  2. workflow_dispatch with tag → inputs.tag
  3. workflow_dispatch w/o tag  → leave package.json untouched
                                  (manual smoke test from a branch)

Leading "v" prefix is stripped, so v0.4.1 → 0.4.1 in the filename.

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr