### PR TITLE
feat: finish issue #8 — edit custom cameras, sensor modes, calc trace…

### DIFF
--- a/src/components/Sidebar/CalculationBreakdown.tsx
+++ b/src/components/Sidebar/CalculationBreakdown.tsx
@@ -1,0 +1,135 @@
+import type { Camera, Lens, SensorSize, FovResult, DofResult } from '../../types';
+
+/**
+ * Step-by-step rendering of the optical formulas used by the calculator, with
+ * the camera's current values substituted in. Useful for sanity-checking the
+ * outputs in the sidebar without having to re-derive the math by hand.
+ *
+ * The formulas mirror `src/utils/fov.ts` exactly. Numeric formatting is kept
+ * compact (≤ 3 decimals) so the table fits in the narrow camera card column.
+ */
+interface CalculationBreakdownProps {
+  camDef: Camera;
+  lensDef: Lens;
+  sensor: SensorSize;
+  fov: FovResult;
+  dof: DofResult;
+  focalLength: number;
+  extender: number;
+  aperture: number;
+  focusDistance: number;
+}
+
+const fmt = (n: number, digits = 2): string => {
+  if (!isFinite(n)) return '∞';
+  const abs = Math.abs(n);
+  if (abs >= 1000) return n.toFixed(0);
+  if (abs >= 10) return n.toFixed(1);
+  if (abs >= 1) return n.toFixed(digits);
+  if (abs >= 0.01) return n.toFixed(3);
+  return n.toExponential(2);
+};
+
+export function CalculationBreakdown({
+  sensor,
+  fov,
+  dof,
+  focalLength,
+  extender,
+  aperture,
+  focusDistance,
+}: CalculationBreakdownProps) {
+  const W = sensor.widthMm;
+  const H = sensor.heightMm;
+  const f = focalLength;
+  const ext = extender;
+  const fe = f * ext; // effective focal length
+  const N = aperture;
+  const c = dof.circleOfConfusion; // mm
+  const s = focusDistance; // m
+  const D = Math.sqrt(W * W + H * H); // sensor diagonal in mm
+  const personH = 1.8;
+
+  // Person height in pixels (matches utils/fov.ts:personHeightInFrame)
+  const imgH = fov.imageHeightAtDistance;
+  const personPx = (personH / imgH) * 1080;
+
+  const Row = ({ label, expr, color = 'text-gray-300' }: { label: string; expr: React.ReactNode; color?: string }) => (
+    <div className="grid grid-cols-12 gap-1 leading-snug">
+      <div className={`col-span-3 ${color} font-semibold`}>{label}</div>
+      <div className="col-span-9 text-gray-400 break-words">{expr}</div>
+    </div>
+  );
+
+  return (
+    <div className="bg-bc-dark rounded p-2 border border-bc-border text-[10px] font-mono space-y-1">
+      <div className="text-bc-accent font-bold text-[11px] mb-1">CALCULATION TRACE</div>
+
+      <div className="text-gray-500 text-[9px] -mt-0.5 mb-1">
+        Sensor {sensor.name} · W={fmt(W)} mm · H={fmt(H)} mm · diag D={fmt(D)} mm
+        {ext !== 1 && <> · f_eff = {fmt(f)} × {ext} = {fmt(fe)} mm</>}
+      </div>
+
+      <Row
+        label="FOV_h"
+        expr={<>2·atan(W / (2·f_eff)) = 2·atan({fmt(W)} / (2·{fmt(fe)})) = <span className="text-bc-green">{fmt(fov.horizontalDeg)}°</span></>}
+      />
+      <Row
+        label="FOV_v"
+        expr={<>2·atan(H / (2·f_eff)) = 2·atan({fmt(H)} / (2·{fmt(fe)})) = <span className="text-bc-green">{fmt(fov.verticalDeg)}°</span></>}
+      />
+      <Row
+        label="FOV_d"
+        expr={<>2·atan(D / (2·f_eff)) = 2·atan({fmt(D)} / (2·{fmt(fe)})) = <span className="text-bc-green">{fmt(fov.diagonalDeg)}°</span></>}
+      />
+      <Row
+        label="Img W"
+        expr={<>2·d·tan(FOV_h/2) = 2·{fmt(s)}·tan({fmt(fov.horizontalDeg / 2)}°) = <span className="text-bc-green">{fmt(fov.imageWidthAtDistance)} m</span></>}
+      />
+      <Row
+        label="Img H"
+        expr={<>2·d·tan(FOV_v/2) = 2·{fmt(s)}·tan({fmt(fov.verticalDeg / 2)}°) = <span className="text-bc-green">{fmt(fov.imageHeightAtDistance)} m</span></>}
+      />
+      <Row
+        label="35mm eq"
+        expr={<>f_eff · crop = {fmt(fe)} · {fmt(sensor.cropFactor, 3)} = <span className="text-bc-green">{fmt(fov.equivalentFocalLength)} mm</span></>}
+      />
+
+      <div className="border-t border-bc-border my-1" />
+
+      <Row
+        label="CoC"
+        expr={<>D / 1500 = {fmt(D)} / 1500 = <span className="text-bc-yellow">{(c * 1000).toFixed(1)} µm</span></>}
+        color="text-gray-300"
+      />
+      <Row
+        label="Hyperf."
+        expr={<>f_eff² / (N·c)/1000 + f_eff/1000 = {fmt(fe)}² / ({fmt(N)}·{fmt(c, 4)})/1000 + {fmt(fe)}/1000 = <span className="text-bc-yellow">{fmt(dof.hyperfocal)} m</span></>}
+        color="text-gray-300"
+      />
+      <Row
+        label="DoF near"
+        expr={<>(H·s) / (H + s − f_eff/1000) = ({fmt(dof.hyperfocal)}·{fmt(s)}) / ({fmt(dof.hyperfocal)} + {fmt(s)} − {fmt(fe / 1000, 3)}) = <span className="text-bc-yellow">{fmt(dof.nearLimit)} m</span></>}
+        color="text-gray-300"
+      />
+      <Row
+        label="DoF far"
+        expr={<>(H·s) / (H − s + f_eff/1000) = ({fmt(dof.hyperfocal)}·{fmt(s)}) / ({fmt(dof.hyperfocal)} − {fmt(s)} + {fmt(fe / 1000, 3)}) = <span className="text-bc-yellow">{fmt(dof.farLimit)} m</span></>}
+        color="text-gray-300"
+      />
+      <Row
+        label="DoF total"
+        expr={<>far − near = {fmt(dof.farLimit)} − {fmt(dof.nearLimit)} = <span className="text-bc-yellow">{fmt(dof.totalDof)} m</span></>}
+        color="text-gray-300"
+      />
+
+      <div className="border-t border-bc-border my-1" />
+
+      <Row
+        label="Person"
+        expr={<>1.80 / img_h · 1080 = 1.80 / {fmt(imgH)} · 1080 = <span className="text-bc-red">{fmt(personPx, 0)} px</span> ({fmt((personPx / 1080) * 100, 1)}%)</>}
+        color="text-gray-300"
+      />
+    </div>
+  );
+}

--- a/src/components/Sidebar/CustomCameraForm.tsx
+++ b/src/components/Sidebar/CustomCameraForm.tsx
@@ -1,0 +1,490 @@
+import { useState } from 'react';
+import { FiPlus, FiTrash2, FiKey, FiZap, FiX } from 'react-icons/fi';
+import { SENSORS } from '../../data/cameras';
+import type { Camera, SensorSize } from '../../types';
+
+/**
+ * Shared form for both creating and editing a custom camera. Used inline in the
+ * camera-card "Custom+" dropdown entry AND in the standalone Custom Camera
+ * Library section of the sidebar.
+ *
+ *  - `initial` populates the fields for edit mode; undefined means create mode.
+ *  - The form supports an arbitrary list of sensor crop modes (e.g. mirror an
+ *    URSA Broadcast G2's 6K / 4K S16 / 2/3" B4 modes) with auto-calculated
+ *    crop factor against the 43.267 mm full-frame diagonal.
+ *  - Adapter mounts are a multi-select (mount plates the body can swap to).
+ *  - When a Gemini API key is stored in localStorage, an "Auto-fill from AI"
+ *    button calls the Gemini API to populate the fields from a manufacturer +
+ *    model name. The key is set/cleared via the inline ⚙ key button.
+ */
+
+const GEMINI_KEY_STORAGE = 'multicam-gemini-api-key';
+const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+
+const MOUNTS = ['B4', 'EF', 'PL', 'E', 'MFT', 'RF', 'L', 'FZ', 'integrated', 'M12'] as const;
+const TYPES = [
+  { value: 'broadcast', label: 'Broadcast' },
+  { value: 'cinema', label: 'Cinema' },
+  { value: 'ptz', label: 'PTZ' },
+  { value: 'mirrorless', label: 'Mirrorless' },
+  { value: 'camcorder', label: 'Camcorder' },
+  { value: 'eng', label: 'ENG' },
+] as const;
+
+type ModeRow = { name: string; widthMm: string; heightMm: string };
+
+interface CustomCameraFormProps {
+  /** Populated for edit mode, undefined for create mode. */
+  initial?: Camera;
+  onSubmit: (cam: Omit<Camera, 'id'>) => void;
+  onCancel: () => void;
+  submitLabel?: string;
+  /** Title shown at the top of the form. */
+  title?: string;
+}
+
+function diagToCropFactor(w: number, h: number) {
+  if (!w || !h) return 1;
+  return 43.267 / Math.sqrt(w * w + h * h);
+}
+
+function detectSensorPreset(sensor?: SensorSize): string {
+  if (!sensor) return 'S35';
+  for (const [key, s] of Object.entries(SENSORS)) {
+    if (Math.abs(s.widthMm - sensor.widthMm) < 0.05 && Math.abs(s.heightMm - sensor.heightMm) < 0.05) {
+      return key;
+    }
+  }
+  return '__custom__';
+}
+
+export function CustomCameraForm({ initial, onSubmit, onCancel, submitLabel = 'Create', title = 'New Custom Camera' }: CustomCameraFormProps) {
+  const [manufacturer, setManufacturer] = useState(initial?.manufacturer ?? '');
+  const [model, setModel] = useState(initial?.model ?? '');
+  const [mount, setMount] = useState<string>(initial?.mount ?? 'EF');
+  const [type, setType] = useState<Camera['type']>(initial?.type ?? 'cinema');
+  const [adaptedMounts, setAdaptedMounts] = useState<string[]>(initial?.adaptedMounts ?? []);
+
+  // Sensor: either a preset key or '__custom__' with explicit dimensions.
+  const initialPreset = detectSensorPreset(initial?.sensor);
+  const [sensorKey, setSensorKey] = useState<string>(initialPreset);
+  const [sensorW, setSensorW] = useState<string>(initialPreset === '__custom__' ? String(initial?.sensor.widthMm ?? '') : '');
+  const [sensorH, setSensorH] = useState<string>(initialPreset === '__custom__' ? String(initial?.sensor.heightMm ?? '') : '');
+  const [sensorName, setSensorName] = useState<string>(initialPreset === '__custom__' ? (initial?.sensor.name ?? '') : '');
+
+  const [modes, setModes] = useState<ModeRow[]>(
+    (initial?.sensorModes ?? []).map((m) => ({ name: m.name, widthMm: String(m.widthMm), heightMm: String(m.heightMm) })),
+  );
+
+  // Gemini state
+  const [apiKey, setApiKey] = useState<string>(() => localStorage.getItem(GEMINI_KEY_STORAGE) ?? '');
+  const [showKeyInput, setShowKeyInput] = useState(false);
+  const [pendingKey, setPendingKey] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
+
+  const addMode = () => setModes([...modes, { name: '', widthMm: '', heightMm: '' }]);
+  const removeMode = (i: number) => setModes(modes.filter((_, idx) => idx !== i));
+  const patchMode = (i: number, patch: Partial<ModeRow>) =>
+    setModes(modes.map((m, idx) => (idx === i ? { ...m, ...patch } : m)));
+
+  const handleSubmit = () => {
+    if (!manufacturer.trim() || !model.trim()) return;
+
+    let sensor: SensorSize;
+    if (sensorKey === '__custom__') {
+      const w = parseFloat(sensorW);
+      const h = parseFloat(sensorH);
+      if (!w || !h) { alert('Enter sensor width and height in mm.'); return; }
+      sensor = {
+        name: sensorName.trim() || `${w}×${h}mm`,
+        widthMm: w,
+        heightMm: h,
+        cropFactor: diagToCropFactor(w, h),
+      };
+    } else {
+      sensor = SENSORS[sensorKey];
+    }
+
+    // Build sensorModes from non-empty rows
+    const parsedModes: SensorSize[] = [];
+    for (const m of modes) {
+      const w = parseFloat(m.widthMm);
+      const h = parseFloat(m.heightMm);
+      if (!w || !h) continue;
+      parsedModes.push({
+        name: m.name.trim() || `${w}×${h}mm`,
+        widthMm: w,
+        heightMm: h,
+        cropFactor: diagToCropFactor(w, h),
+      });
+    }
+
+    onSubmit({
+      manufacturer: manufacturer.trim(),
+      model: model.trim(),
+      sensor,
+      mount,
+      adaptedMounts: adaptedMounts.length > 0 ? adaptedMounts : undefined,
+      resolutions: initial?.resolutions ?? ['HD'],
+      type,
+      sensorModes: parsedModes.length > 0 ? parsedModes : undefined,
+    });
+  };
+
+  const runAiAutofill = async () => {
+    if (!apiKey) { setShowKeyInput(true); return; }
+    if (!manufacturer.trim() && !model.trim()) {
+      setAiError('Enter at least a manufacturer or model first.');
+      return;
+    }
+    setAiLoading(true);
+    setAiError(null);
+    try {
+      const prompt = buildPrompt(manufacturer, model);
+      const data = await callGemini(apiKey, prompt);
+      applyAiResult(data);
+    } catch (err: any) {
+      setAiError(err?.message ?? 'AI request failed');
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
+  const applyAiResult = (data: any) => {
+    if (data.manufacturer && !manufacturer.trim()) setManufacturer(String(data.manufacturer));
+    if (data.model && !model.trim()) setModel(String(data.model));
+    if (data.mount && (MOUNTS as readonly string[]).includes(data.mount)) setMount(data.mount);
+    if (data.type && TYPES.some((t) => t.value === data.type)) setType(data.type);
+    if (Array.isArray(data.adaptedMounts)) {
+      setAdaptedMounts(data.adaptedMounts.filter((m: any) => typeof m === 'string' && (MOUNTS as readonly string[]).includes(m)));
+    }
+    if (data.sensor && typeof data.sensor.widthMm === 'number' && typeof data.sensor.heightMm === 'number') {
+      setSensorKey('__custom__');
+      setSensorName(String(data.sensor.name ?? ''));
+      setSensorW(String(data.sensor.widthMm));
+      setSensorH(String(data.sensor.heightMm));
+    }
+    if (Array.isArray(data.sensorModes)) {
+      setModes(
+        data.sensorModes
+          .filter((m: any) => m && typeof m.widthMm === 'number' && typeof m.heightMm === 'number')
+          .map((m: any) => ({
+            name: String(m.name ?? ''),
+            widthMm: String(m.widthMm),
+            heightMm: String(m.heightMm),
+          })),
+      );
+    }
+  };
+
+  const saveKey = () => {
+    const trimmed = pendingKey.trim();
+    if (trimmed) {
+      localStorage.setItem(GEMINI_KEY_STORAGE, trimmed);
+      setApiKey(trimmed);
+    }
+    setPendingKey('');
+    setShowKeyInput(false);
+  };
+
+  const clearKey = () => {
+    localStorage.removeItem(GEMINI_KEY_STORAGE);
+    setApiKey('');
+    setPendingKey('');
+    setShowKeyInput(false);
+  };
+
+  return (
+    <div className="bg-bc-dark rounded p-2 border border-bc-border space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-gray-300 font-medium text-[11px]">{title}</span>
+        <div className="flex items-center gap-1">
+          {apiKey && (
+            <button
+              type="button"
+              onClick={runAiAutofill}
+              disabled={aiLoading}
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30 disabled:opacity-50"
+              title="Auto-fill the form from Gemini AI based on the manufacturer + model"
+            >
+              <FiZap size={10} /> {aiLoading ? 'Asking AI…' : 'AI auto-fill'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => { setPendingKey(apiKey); setShowKeyInput(!showKeyInput); }}
+            className="p-1 rounded text-gray-500 hover:text-bc-accent"
+            title={apiKey ? 'Manage Gemini API key' : 'Set Gemini API key for AI auto-fill'}
+          >
+            <FiKey size={11} />
+          </button>
+          <button onClick={onCancel} className="text-gray-500 hover:text-white text-xs">
+            <FiX size={11} />
+          </button>
+        </div>
+      </div>
+
+      {showKeyInput && (
+        <div className="bg-bc-panel rounded p-1.5 border border-bc-border space-y-1">
+          <div className="text-[10px] text-gray-500 leading-tight">
+            Paste a free Gemini API key from <span className="text-bc-accent">aistudio.google.com</span>.
+            Stored locally only.
+          </div>
+          <input
+            type="password"
+            className="w-full bg-bc-dark border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+            placeholder="AIza…"
+            value={pendingKey}
+            onChange={(e) => setPendingKey(e.target.value)}
+          />
+          <div className="flex gap-1">
+            <button onClick={saveKey} className="flex-1 py-0.5 rounded bg-bc-green/20 text-bc-green text-[10px] hover:bg-bc-green/30">Save</button>
+            {apiKey && (
+              <button onClick={clearKey} className="flex-1 py-0.5 rounded bg-bc-red/20 text-bc-red text-[10px] hover:bg-bc-red/30">Clear</button>
+            )}
+            <button onClick={() => setShowKeyInput(false)} className="flex-1 py-0.5 rounded bg-bc-dark border border-bc-border text-gray-400 text-[10px] hover:text-gray-200">Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {aiError && (
+        <div className="text-[10px] text-bc-red bg-bc-red/10 border border-bc-red/30 rounded px-1.5 py-1">
+          {aiError}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-1">
+        <input
+          placeholder="Manufacturer"
+          className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+          value={manufacturer}
+          onChange={(e) => setManufacturer(e.target.value)}
+        />
+        <input
+          placeholder="Model"
+          className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        />
+      </div>
+
+      <label className="block">
+        <span className="text-gray-500 text-[10px]">Sensor</span>
+        <select
+          className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+          value={sensorKey}
+          onChange={(e) => setSensorKey(e.target.value)}
+        >
+          {Object.entries(SENSORS).map(([key, s]) => (
+            <option key={key} value={key}>{s.name} ({s.widthMm}×{s.heightMm}mm)</option>
+          ))}
+          <option value="__custom__">Custom size…</option>
+        </select>
+      </label>
+      {sensorKey === '__custom__' && (
+        <div className="grid grid-cols-3 gap-1">
+          <input
+            placeholder="Name"
+            className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+            value={sensorName}
+            onChange={(e) => setSensorName(e.target.value)}
+          />
+          <input
+            type="number"
+            step="0.01"
+            placeholder="Width mm"
+            className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+            value={sensorW}
+            onChange={(e) => setSensorW(e.target.value)}
+          />
+          <input
+            type="number"
+            step="0.01"
+            placeholder="Height mm"
+            className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+            value={sensorH}
+            onChange={(e) => setSensorH(e.target.value)}
+          />
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-1">
+        <label>
+          <span className="text-gray-500 text-[10px]">Native Mount</span>
+          <select
+            className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+            value={mount}
+            onChange={(e) => {
+              const m = e.target.value;
+              // Drop the new native from the adapter list if it was checked
+              setMount(m);
+              setAdaptedMounts(adaptedMounts.filter((x) => x !== m));
+            }}
+          >
+            {MOUNTS.map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span className="text-gray-500 text-[10px]">Type</span>
+          <select
+            className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
+            value={type}
+            onChange={(e) => setType(e.target.value as Camera['type'])}
+          >
+            {TYPES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div>
+        <span className="text-gray-500 text-[10px]">Available adapters / mount plates</span>
+        <div className="grid grid-cols-4 gap-1 mt-0.5">
+          {MOUNTS.filter((m) => m !== mount && m !== 'integrated' && m !== 'M12').map((m) => {
+            const checked = adaptedMounts.includes(m);
+            return (
+              <label key={m} className="flex items-center gap-1 text-[10px] text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="accent-bc-accent"
+                  checked={checked}
+                  onChange={(e) => {
+                    setAdaptedMounts(
+                      e.target.checked ? [...adaptedMounts, m] : adaptedMounts.filter((x) => x !== m),
+                    );
+                  }}
+                />
+                {m}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500 text-[10px]">Sensor modes (hardware crops, optional)</span>
+          <button
+            type="button"
+            onClick={addMode}
+            className="flex items-center gap-1 px-1 py-0.5 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30"
+          >
+            <FiPlus size={10} /> Add mode
+          </button>
+        </div>
+        {modes.map((m, i) => {
+          const w = parseFloat(m.widthMm);
+          const h = parseFloat(m.heightMm);
+          const cf = w && h ? diagToCropFactor(w, h) : 0;
+          return (
+            <div key={i} className="grid grid-cols-12 gap-1 mt-0.5 items-center">
+              <input
+                placeholder="Name"
+                className="col-span-5 bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[11px]"
+                value={m.name}
+                onChange={(e) => patchMode(i, { name: e.target.value })}
+              />
+              <input
+                type="number"
+                step="0.01"
+                placeholder="W mm"
+                className="col-span-3 bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[11px]"
+                value={m.widthMm}
+                onChange={(e) => patchMode(i, { widthMm: e.target.value })}
+              />
+              <input
+                type="number"
+                step="0.01"
+                placeholder="H mm"
+                className="col-span-3 bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[11px]"
+                value={m.heightMm}
+                onChange={(e) => patchMode(i, { heightMm: e.target.value })}
+              />
+              <button
+                type="button"
+                onClick={() => removeMode(i)}
+                className="col-span-1 p-0.5 text-gray-500 hover:text-bc-red"
+                title="Remove mode"
+              >
+                <FiTrash2 size={11} />
+              </button>
+              {cf > 0 && (
+                <span className="col-span-12 text-[9px] text-gray-500 -mt-0.5">
+                  → crop factor ×{cf.toFixed(2)}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        disabled={!manufacturer.trim() || !model.trim()}
+        className="flex items-center gap-1 px-2 py-1 rounded bg-bc-green/20 text-bc-green text-xs hover:bg-bc-green/30 w-full justify-center disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <FiPlus size={12} /> {submitLabel}
+      </button>
+    </div>
+  );
+}
+
+// ── Gemini helpers ───────────────────────────────────────────────────────────
+
+function buildPrompt(manufacturer: string, model: string): string {
+  return [
+    'You are a broadcast/cinema camera specification database.',
+    'Return ONLY a JSON object matching this schema (no markdown, no commentary):',
+    '{',
+    '  "manufacturer": string,',
+    '  "model": string,',
+    '  "sensor": { "name": string, "widthMm": number, "heightMm": number },',
+    '  "mount": "B4"|"EF"|"PL"|"E"|"MFT"|"RF"|"L"|"FZ"|"integrated"|"M12",',
+    '  "adaptedMounts": string[],   // mount plates the body can swap to, excluding the native mount',
+    '  "type": "broadcast"|"cinema"|"ptz"|"mirrorless"|"camcorder"|"eng",',
+    '  "sensorModes": [{ "name": string, "widthMm": number, "heightMm": number }]',
+    '}',
+    '',
+    'Fill every field you can confirm; omit any you cannot. sensorModes should',
+    "list ALL distinct hardware sensor crop modes the body exposes (e.g. URSA",
+    "Broadcast G2 has 6K Full, 4K UHD S16, 2/3\" B4 crop). Skip sensorModes if",
+    'there is only one. adaptedMounts must NOT include the native mount.',
+    '',
+    `Camera:`,
+    `Manufacturer: ${manufacturer || '(unknown)'}`,
+    `Model: ${model || '(unknown)'}`,
+  ].join('\n');
+}
+
+async function callGemini(apiKey: string, prompt: string): Promise<any> {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: {
+        responseMimeType: 'application/json',
+        temperature: 0.2,
+      },
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Gemini ${response.status}: ${text.slice(0, 200) || response.statusText}`);
+  }
+  const data = await response.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text) throw new Error('Gemini returned an empty response');
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Some responses include code fences even with responseMimeType=application/json
+    const stripped = text.replace(/^```(?:json)?/i, '').replace(/```\s*$/, '').trim();
+    return JSON.parse(stripped);
+  }
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,10 +1,12 @@
 import { useStore } from '../../store/useStore';
-import { CAMERAS, SENSORS, getCameraById, getAdapterInfo, getEffectiveSensor } from '../../data/cameras';
+import { CAMERAS, getCameraById, getAdapterInfo, getEffectiveSensor } from '../../data/cameras';
 import { LENSES, getLensById, getCompatibleLenses } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
-import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiCamera } from 'react-icons/fi';
+import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiCamera, FiEdit2 } from 'react-icons/fi';
 import { useState, useRef, useCallback, useEffect } from 'react';
-import type { BackgroundPlan, StageObjectType } from '../../types';
+import type { BackgroundPlan, StageObjectType, Camera } from '../../types';
+import { CustomCameraForm } from './CustomCameraForm';
+import { CalculationBreakdown } from './CalculationBreakdown';
 import * as pdfjsLib from 'pdfjs-dist';
 
 /** Group lenses by mount for the dropdown */
@@ -53,17 +55,7 @@ function CameraCard({ camId }: { camId: string }) {
   const [showNewLens, setShowNewLens] = useState(false);
   const [newLens, setNewLens] = useState({ manufacturer: '', model: '', focalMin: '10', focalMax: '100', aperture: '2.8', mount: 'B4', type: 'zoom' as 'zoom' | 'prime' });
   const [showNewCustomCam, setShowNewCustomCam] = useState(false);
-  const [newCustomCam, setNewCustomCam] = useState({
-    manufacturer: '',
-    model: '',
-    sensorKey: 'S35',
-    sensorW: '',
-    sensorH: '',
-    sensorName: '',
-    mount: 'EF',
-    adaptedMounts: [] as string[],
-    type: 'cinema' as 'broadcast' | 'cinema' | 'ptz' | 'mirrorless' | 'camcorder' | 'eng',
-  });
+  const [showCalc, setShowCalc] = useState(false);
 
   const { customCameras, addCustomCamera } = useStore();
   const camDef = getCameraById(cam.cameraId, customCameras);
@@ -202,180 +194,28 @@ function CameraCard({ camId }: { camId: string }) {
             </select>
           </label>
 
-          {/* Inline custom camera creation form */}
+          {/* Inline custom camera creation form (Custom+ entry in the dropdown) */}
           {showNewCustomCam && (
-            <div className="bg-bc-dark rounded p-2 border border-bc-border space-y-1.5">
-              <div className="flex items-center justify-between">
-                <span className="text-gray-300 font-medium text-[11px]">New Custom Camera</span>
-                <button onClick={() => setShowNewCustomCam(false)} className="text-gray-500 hover:text-white text-xs">✕</button>
-              </div>
-              <div className="grid grid-cols-2 gap-1">
-                <input
-                  placeholder="Manufacturer"
-                  className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                  value={newCustomCam.manufacturer}
-                  onChange={(e) => setNewCustomCam({ ...newCustomCam, manufacturer: e.target.value })}
-                />
-                <input
-                  placeholder="Model"
-                  className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                  value={newCustomCam.model}
-                  onChange={(e) => setNewCustomCam({ ...newCustomCam, model: e.target.value })}
-                />
-              </div>
-              <label className="block">
-                <span className="text-gray-500 text-[10px]">Sensor</span>
-                <select
-                  className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                  value={newCustomCam.sensorKey}
-                  onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorKey: e.target.value })}
-                >
-                  {Object.entries(SENSORS).map(([key, s]) => (
-                    <option key={key} value={key}>{s.name} ({s.widthMm}×{s.heightMm}mm)</option>
-                  ))}
-                  <option value="__custom__">Custom size…</option>
-                </select>
-              </label>
-              {newCustomCam.sensorKey === '__custom__' && (
-                <div className="grid grid-cols-3 gap-1">
-                  <input
-                    placeholder="Name"
-                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.sensorName}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorName: e.target.value })}
-                  />
-                  <input
-                    type="number"
-                    step="0.01"
-                    placeholder="Width mm"
-                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.sensorW}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorW: e.target.value })}
-                  />
-                  <input
-                    type="number"
-                    step="0.01"
-                    placeholder="Height mm"
-                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.sensorH}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorH: e.target.value })}
-                  />
-                </div>
-              )}
-              <div className="grid grid-cols-2 gap-1">
-                <label>
-                  <span className="text-gray-500 text-[10px]">Native Mount</span>
-                  <select
-                    className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.mount}
-                    onChange={(e) => {
-                      const m = e.target.value;
-                      // Avoid duplicating the native mount in the adapter list
-                      setNewCustomCam({ ...newCustomCam, mount: m, adaptedMounts: newCustomCam.adaptedMounts.filter((x) => x !== m) });
-                    }}
-                  >
-                    {['B4', 'EF', 'PL', 'E', 'MFT', 'RF', 'L', 'FZ', 'integrated', 'M12'].map((m) => (
-                      <option key={m} value={m}>{m}</option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  <span className="text-gray-500 text-[10px]">Type</span>
-                  <select
-                    className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.type}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, type: e.target.value as typeof newCustomCam.type })}
-                  >
-                    <option value="broadcast">Broadcast</option>
-                    <option value="cinema">Cinema</option>
-                    <option value="ptz">PTZ</option>
-                    <option value="mirrorless">Mirrorless</option>
-                    <option value="camcorder">Camcorder</option>
-                    <option value="eng">ENG</option>
-                  </select>
-                </label>
-              </div>
-              {/* Adapter mounts — multi-select via checkboxes so the user can mark
-                  every mount plate the body can accept (e.g. URSA Broadcast G2
-                  B4 native + EF + PL). The native mount itself is excluded. */}
-              <div>
-                <span className="text-gray-500 text-[10px]">Available adapters / mount plates</span>
-                <div className="grid grid-cols-4 gap-1 mt-0.5">
-                  {['B4', 'EF', 'PL', 'E', 'MFT', 'RF', 'L', 'FZ'].filter((m) => m !== newCustomCam.mount).map((m) => {
-                    const checked = newCustomCam.adaptedMounts.includes(m);
-                    return (
-                      <label key={m} className="flex items-center gap-1 text-[10px] text-gray-300 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          className="accent-bc-accent"
-                          checked={checked}
-                          onChange={(e) => {
-                            setNewCustomCam({
-                              ...newCustomCam,
-                              adaptedMounts: e.target.checked
-                                ? [...newCustomCam.adaptedMounts, m]
-                                : newCustomCam.adaptedMounts.filter((x) => x !== m),
-                            });
-                          }}
-                        />
-                        {m}
-                      </label>
-                    );
-                  })}
-                </div>
-              </div>
-              <button
-                onClick={() => {
-                  if (!newCustomCam.manufacturer.trim() || !newCustomCam.model.trim()) return;
-                  let sensor;
-                  if (newCustomCam.sensorKey === '__custom__') {
-                    const w = parseFloat(newCustomCam.sensorW);
-                    const h = parseFloat(newCustomCam.sensorH);
-                    if (!w || !h) { alert('Enter sensor width and height in mm.'); return; }
-                    const diag = Math.sqrt(w * w + h * h);
-                    const cropFactor = 43.267 / diag;
-                    sensor = {
-                      name: newCustomCam.sensorName.trim() || `${w}×${h}mm`,
-                      widthMm: w,
-                      heightMm: h,
-                      cropFactor,
-                    };
-                  } else {
-                    sensor = SENSORS[newCustomCam.sensorKey];
-                  }
-                  const newId = addCustomCamera({
-                    manufacturer: newCustomCam.manufacturer.trim(),
-                    model: newCustomCam.model.trim(),
-                    sensor,
-                    mount: newCustomCam.mount,
-                    adaptedMounts: newCustomCam.adaptedMounts.length > 0 ? newCustomCam.adaptedMounts : undefined,
-                    resolutions: ['HD'],
-                    type: newCustomCam.type,
-                  });
-                  // Auto-select the new camera on this card
-                  const firstLens = getCompatibleLenses(newCustomCam.mount, newCustomCam.adaptedMounts)[0];
-                  updateCamera(cam.id, {
-                    cameraId: newId,
-                    activeMount: newCustomCam.mount,
-                    lensId: firstLens?.id ?? cam.lensId,
-                    focalLength: firstLens?.focalLengthMin ?? cam.focalLength,
-                    aperture: firstLens?.maxApertureWide ?? cam.aperture,
-                    extenderActive: 1,
-                    useSpeedbooster: false,
-                    sensorModeIndex: undefined,
-                  });
-                  setNewCustomCam({
-                    manufacturer: '', model: '', sensorKey: 'S35', sensorW: '', sensorH: '',
-                    sensorName: '', mount: 'EF', adaptedMounts: [], type: 'cinema',
-                  });
-                  setShowNewCustomCam(false);
-                }}
-                disabled={!newCustomCam.manufacturer.trim() || !newCustomCam.model.trim()}
-                className="flex items-center gap-1 px-2 py-1 rounded bg-bc-green/20 text-bc-green text-xs hover:bg-bc-green/30 w-full justify-center disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <FiPlus size={12} /> Create & Select
-              </button>
-            </div>
+            <CustomCameraForm
+              title="New Custom Camera"
+              submitLabel="Create & Select"
+              onCancel={() => setShowNewCustomCam(false)}
+              onSubmit={(spec) => {
+                const newId = addCustomCamera(spec);
+                const firstLens = getCompatibleLenses(spec.mount, spec.adaptedMounts)[0];
+                updateCamera(cam.id, {
+                  cameraId: newId,
+                  activeMount: spec.mount,
+                  lensId: firstLens?.id ?? cam.lensId,
+                  focalLength: firstLens?.focalLengthMin ?? cam.focalLength,
+                  aperture: firstLens?.maxApertureWide ?? cam.aperture,
+                  extenderActive: 1,
+                  useSpeedbooster: false,
+                  sensorModeIndex: spec.sensorModes && spec.sensorModes.length > 0 ? 0 : undefined,
+                });
+                setShowNewCustomCam(false);
+              }}
+            />
           )}
 
           {/* Mount selector — only visible when the body offers swappable mount plates */}
@@ -739,6 +579,34 @@ function CameraCard({ camId }: { camId: string }) {
               Eff. Sensor: {effectiveSensor.name} (crop ×{effectiveSensor.cropFactor.toFixed(1)})
             </div>
           )}
+
+          {/* Calculation trace — step-by-step formula breakdown */}
+          {camDef && lensDef && effectiveSensor && fov && dof && (
+            <div>
+              <button
+                onClick={() => setShowCalc(!showCalc)}
+                className="flex items-center gap-1 text-[10px] text-gray-400 hover:text-bc-accent w-full"
+              >
+                {showCalc ? <FiChevronUp size={11} /> : <FiChevronDown size={11} />}
+                {showCalc ? 'Hide' : 'Show'} calculation breakdown
+              </button>
+              {showCalc && (
+                <div className="mt-1">
+                  <CalculationBreakdown
+                    camDef={camDef}
+                    lensDef={lensDef}
+                    sensor={effectiveSensor}
+                    fov={fov}
+                    dof={dof}
+                    focalLength={cam.focalLength}
+                    extender={cam.extenderActive}
+                    aperture={cam.aperture}
+                    focusDistance={cam.focusDistance}
+                  />
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -753,7 +621,7 @@ export default function Sidebar() {
     persons, addPerson, addStageObject, removePerson, updatePerson,
     backgroundPlan, setBackgroundPlan,
     walls, addWall, removeWall, updateWall,
-    customCameras, addCustomCamera, removeCustomCamera,
+    customCameras, addCustomCamera, updateCustomCamera, removeCustomCamera,
   } = useStore();
   const [venueOpen, setVenueOpen] = useState(false);
   const [stagesOpen, setStagesOpen] = useState(false);
@@ -762,16 +630,7 @@ export default function Sidebar() {
   const [bgOpen, setBgOpen] = useState(false);
   const [customCamsOpen, setCustomCamsOpen] = useState(false);
   const [showAddCustomCam, setShowAddCustomCam] = useState(false);
-  const [newCustomCam, setNewCustomCam] = useState({
-    manufacturer: '',
-    model: '',
-    mount: 'EF',
-    type: 'cinema' as 'broadcast' | 'cinema' | 'ptz' | 'mirrorless' | 'camcorder' | 'eng',
-    sensorKey: 'S35',
-    sensorW: '',
-    sensorH: '',
-    sensorName: '',
-  });
+  const [editingCustomCamId, setEditingCustomCamId] = useState<string | null>(null);
   const [wallDrawMode, setWallDrawMode] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [calibAxis, setCalibAxis] = useState<'x' | 'y' | null>(null);
@@ -1234,153 +1093,65 @@ export default function Sidebar() {
             {customCameras.length === 0 && !showAddCustomCam && (
               <p className="text-gray-500 text-[10px]">No custom cameras. Add a body for non-listed gear.</p>
             )}
-            {customCameras.map((c) => (
-              <div key={c.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
-                <span className="text-white text-xs flex-1 truncate">{c.manufacturer} {c.model}</span>
-                <span className="text-gray-500 text-[10px]">{c.mount}</span>
-                <button
-                  onClick={() => {
-                    if (cameras.some((vc) => vc.cameraId === c.id)) {
-                      alert(`Cannot remove "${c.manufacturer} ${c.model}" — it is used by ${cameras.filter((vc) => vc.cameraId === c.id).length} placed camera(s). Remove those first.`);
-                      return;
-                    }
-                    removeCustomCamera(c.id);
-                  }}
-                  className="p-0.5 hover:text-bc-red"
-                  title="Remove custom camera"
-                >
-                  <FiTrash2 size={11} />
-                </button>
-              </div>
-            ))}
-            {showAddCustomCam ? (
-              <div className="bg-bc-dark rounded p-2 border border-bc-border space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <span className="text-gray-300 font-medium text-[11px]">New Custom Camera</span>
-                  <button onClick={() => setShowAddCustomCam(false)} className="text-gray-500 hover:text-white text-xs">✕</button>
-                </div>
-                <div className="grid grid-cols-2 gap-1">
-                  <input
-                    placeholder="Manufacturer"
-                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.manufacturer}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, manufacturer: e.target.value })}
-                  />
-                  <input
-                    placeholder="Model"
-                    className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.model}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, model: e.target.value })}
-                  />
-                </div>
-                <label className="block">
-                  <span className="text-gray-500 text-[10px]">Sensor</span>
-                  <select
-                    className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                    value={newCustomCam.sensorKey}
-                    onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorKey: e.target.value })}
-                  >
-                    {Object.entries(SENSORS).map(([key, s]) => (
-                      <option key={key} value={key}>{s.name} ({s.widthMm}×{s.heightMm}mm)</option>
-                    ))}
-                    <option value="__custom__">Custom size…</option>
-                  </select>
-                </label>
-                {newCustomCam.sensorKey === '__custom__' && (
-                  <div className="grid grid-cols-3 gap-1">
-                    <input
-                      placeholder="Name"
-                      className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                      value={newCustomCam.sensorName}
-                      onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorName: e.target.value })}
-                    />
-                    <input
-                      type="number"
-                      step="0.01"
-                      placeholder="Width mm"
-                      className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                      value={newCustomCam.sensorW}
-                      onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorW: e.target.value })}
-                    />
-                    <input
-                      type="number"
-                      step="0.01"
-                      placeholder="Height mm"
-                      className="bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                      value={newCustomCam.sensorH}
-                      onChange={(e) => setNewCustomCam({ ...newCustomCam, sensorH: e.target.value })}
-                    />
+            {customCameras.map((c) => {
+              const inUse = cameras.filter((vc) => vc.cameraId === c.id).length;
+              const isEditing = editingCustomCamId === c.id;
+              return (
+                <div key={c.id}>
+                  <div className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
+                    <span className="text-white text-xs flex-1 truncate">{c.manufacturer} {c.model}</span>
+                    <span className="text-gray-500 text-[10px]">{c.mount}</span>
+                    {inUse > 0 && (
+                      <span className="text-bc-yellow text-[10px]" title={`Used by ${inUse} placed camera(s)`}>×{inUse}</span>
+                    )}
+                    <button
+                      onClick={() => setEditingCustomCamId(isEditing ? null : c.id)}
+                      className="p-0.5 hover:text-bc-accent"
+                      title="Edit custom camera"
+                    >
+                      <FiEdit2 size={11} />
+                    </button>
+                    <button
+                      onClick={() => {
+                        if (inUse > 0) {
+                          alert(`Cannot remove "${c.manufacturer} ${c.model}" — it is used by ${inUse} placed camera(s). Remove those first.`);
+                          return;
+                        }
+                        removeCustomCamera(c.id);
+                      }}
+                      className="p-0.5 hover:text-bc-red"
+                      title="Remove custom camera"
+                    >
+                      <FiTrash2 size={11} />
+                    </button>
                   </div>
-                )}
-                <div className="grid grid-cols-2 gap-1">
-                  <label>
-                    <span className="text-gray-500 text-[10px]">Mount</span>
-                    <select
-                      className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                      value={newCustomCam.mount}
-                      onChange={(e) => setNewCustomCam({ ...newCustomCam, mount: e.target.value })}
-                    >
-                      {['B4', 'EF', 'PL', 'E', 'MFT', 'RF', 'L', 'FZ', 'integrated', 'M12'].map((m) => (
-                        <option key={m} value={m}>{m}</option>
-                      ))}
-                    </select>
-                  </label>
-                  <label>
-                    <span className="text-gray-500 text-[10px]">Type</span>
-                    <select
-                      className="block w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-xs"
-                      value={newCustomCam.type}
-                      onChange={(e) => setNewCustomCam({ ...newCustomCam, type: e.target.value as typeof newCustomCam.type })}
-                    >
-                      <option value="broadcast">Broadcast</option>
-                      <option value="cinema">Cinema</option>
-                      <option value="ptz">PTZ</option>
-                      <option value="mirrorless">Mirrorless</option>
-                      <option value="camcorder">Camcorder</option>
-                      <option value="eng">ENG</option>
-                    </select>
-                  </label>
+                  {isEditing && (
+                    <div className="mt-1">
+                      <CustomCameraForm
+                        title={`Edit ${c.manufacturer} ${c.model}`}
+                        submitLabel="Save changes"
+                        initial={c as Camera}
+                        onCancel={() => setEditingCustomCamId(null)}
+                        onSubmit={(spec) => {
+                          updateCustomCamera(c.id, spec);
+                          setEditingCustomCamId(null);
+                        }}
+                      />
+                    </div>
+                  )}
                 </div>
-                <button
-                  onClick={() => {
-                    if (!newCustomCam.manufacturer.trim() || !newCustomCam.model.trim()) return;
-                    let sensor;
-                    if (newCustomCam.sensorKey === '__custom__') {
-                      const w = parseFloat(newCustomCam.sensorW);
-                      const h = parseFloat(newCustomCam.sensorH);
-                      if (!w || !h) { alert('Enter sensor width and height in mm.'); return; }
-                      // Diagonal-based crop factor against 43.27mm full-frame diagonal
-                      const diag = Math.sqrt(w * w + h * h);
-                      const cropFactor = 43.267 / diag;
-                      sensor = {
-                        name: newCustomCam.sensorName.trim() || `${w}×${h}mm`,
-                        widthMm: w,
-                        heightMm: h,
-                        cropFactor,
-                      };
-                    } else {
-                      sensor = SENSORS[newCustomCam.sensorKey];
-                    }
-                    addCustomCamera({
-                      manufacturer: newCustomCam.manufacturer.trim(),
-                      model: newCustomCam.model.trim(),
-                      sensor,
-                      mount: newCustomCam.mount,
-                      resolutions: ['HD'],
-                      type: newCustomCam.type,
-                    });
-                    setNewCustomCam({
-                      manufacturer: '', model: '', mount: 'EF', type: 'cinema',
-                      sensorKey: 'S35', sensorW: '', sensorH: '', sensorName: '',
-                    });
-                    setShowAddCustomCam(false);
-                  }}
-                  disabled={!newCustomCam.manufacturer.trim() || !newCustomCam.model.trim()}
-                  className="flex items-center gap-1 px-2 py-1 rounded bg-bc-green/20 text-bc-green text-xs hover:bg-bc-green/30 w-full justify-center disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  <FiPlus size={12} /> Create custom camera
-                </button>
-              </div>
+              );
+            })}
+            {showAddCustomCam ? (
+              <CustomCameraForm
+                title="New Custom Camera"
+                submitLabel="Create custom camera"
+                onCancel={() => setShowAddCustomCam(false)}
+                onSubmit={(spec) => {
+                  addCustomCamera(spec);
+                  setShowAddCustomCam(false);
+                }}
+              />
             ) : (
               <button
                 onClick={() => setShowAddCustomCam(true)}


### PR DESCRIPTION
…, Gemini AI

Closes the remaining items from issue #8 that were deferred at the time the issue was closed.

## Extracted CustomCameraForm component

Both the "Custom+" entry in the camera-card dropdown and the standalone Custom Camera Library section in the sidebar used to carry their own inline form (~175 lines each, almost identical). Both are now thin call-sites to the new `CustomCameraForm` component, which handles create + edit + Gemini auto-fill + sensor modes in one place.

## Edit existing custom cameras

The Library section now shows an Edit (pencil) icon next to each entry. Clicking it expands an inline form pre-filled with the camera's current values; Save persists via the existing updateCustomCamera store action. Inline editing means the user doesn't lose context in the list while making changes. Cameras in active use display an "×N" badge so the user knows how many placed instances will be affected.

## Sensor modes editor

Custom cameras can now declare hardware sensor crop modes the same way built-ins do (e.g. URSA Broadcast G2 has 6K Full / 4K S16 / 2/3" B4 crop). Each mode row has a name field plus width and height in mm; the crop factor is computed automatically against the 43.267 mm full-frame diagonal and shown live. The sensor mode dropdown that already existed for built-ins now also appears for custom cameras with ≥ 2 modes defined.

## Calculation trace ("Rechenweg")

New "Show calculation breakdown" toggle in every camera card. When expanded it renders `CalculationBreakdown`, a step-by-step trace of every formula in src/utils/fov.ts with the camera's current numeric values substituted in: FOV h/v/d, image w/h at distance, 35mm equivalent, CoC, hyperfocal, DoF near/far/total, and person-in-frame height. Useful for sanity-checking against external optical calculators or just understanding what the numbers mean.

## Gemini AI auto-fill

`CustomCameraForm` has a key (🔑) and zap (⚡) button row in the top-right. The key button manages a Gemini API key (stored locally in the multicam-gemini-api-key localStorage entry, clearable from the same UI). Once a key is set, the zap button sends a structured prompt to gemini-2.5-flash-lite asking for the body's sensor / mount / adapter / type / sensorModes by manufacturer + model name, and pre-fills the form from the JSON response. Response parsing tolerates the occasional markdown fence around the JSON.

The user always reviews + edits the AI's answer before hitting Save, so AI mistakes don't leak into the camera library without consent.

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr