### PR TITLE
fix(preview): repaint synchronously on drag — useLayoutEffect for canvas

### DIFF
--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -2,7 +2,7 @@ import { useStore } from '../../store/useStore';
 import { getCameraById, getEffectiveSensor, getAdapterInfo } from '../../data/cameras';
 import { getLensById } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
-import { useRef, useEffect, useCallback, useState } from 'react';
+import { useRef, useEffect, useLayoutEffect, useCallback, useState } from 'react';
 import type { StageObjectType } from '../../types';
 import { FiExternalLink, FiChevronLeft, FiChevronRight } from 'react-icons/fi';
 
@@ -653,11 +653,20 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
 
   }, [cam, venue, persons, cameras, showGrid, showSafeAreas, showThirds, showCrosshair]);
 
-  useEffect(() => {
+  // Repaint synchronously after every render so pan/tilt drags update the canvas
+  // on the very next browser frame. The earlier `useEffect` variant was being
+  // batched by React under fast drag input, so the 2D/3D views (which bind
+  // declaratively to the store) updated immediately while the imperatively-
+  // painted canvas lagged or skipped frames.
+  useLayoutEffect(() => {
     draw();
-    // Redraw on resize
+  }, [draw]);
+
+  // Resize observer lives in a normal effect — not time-critical.
+  useEffect(() => {
+    if (!wrapRef.current) return;
     const ro = new ResizeObserver(() => draw());
-    if (wrapRef.current) ro.observe(wrapRef.current);
+    ro.observe(wrapRef.current);
     return () => ro.disconnect();
   }, [draw]);
 


### PR DESCRIPTION
The Preview's pan/tilt drag updated cam.pan and cam.tilt in the store on every mousemove, and the 2D/3D views (which bind to the store declaratively) reflected those changes immediately. The Preview canvas itself, painted imperatively from a `useEffect`, did not — under continuous high-frequency drag input React kept deferring/batching the effect schedule, so the canvas would only catch up after the drag finished.

Moved the canvas repaint into a `useLayoutEffect`, which runs synchronously after each render and before the browser's next paint. The drag now updates Preview, 2D and 3D in lockstep.

The ResizeObserver (not time-critical) stays in a separate plain `useEffect`.

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr