### PR TITLE
fix(adapters): strict mount→lens contract — no more silent auto-adapter

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '../../store/useStore';
 import { CAMERAS, getCameraById, getAdapterInfo, getEffectiveSensor } from '../../data/cameras';
-import { LENSES, getLensById, getCompatibleLenses } from '../../data/lenses';
+import { LENSES, getLensById, getCompatibleLenses, pickInitialMountAndLens } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
 import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiEdit2, FiRotateCcw } from 'react-icons/fi';
 import { useState, useRef, useCallback, useEffect } from 'react';
@@ -66,18 +66,28 @@ function CameraCard({ camId }: { camId: string }) {
   // the body's mount plate (e.g. URSA Broadcast B4 → EF), only lenses for
   // that plate are physically attachable.
   const activeMount = cam.activeMount ?? camDef?.mount;
+  // Strict: only lenses that physically attach to the active mount.
   const compatLenses = camDef ? getCompatibleLenses(camDef.mount, camDef.adaptedMounts, cam.activeMount) : allLenses;
-  const allCompat = [...compatLenses, ...customLenses.filter((l) => {
-    if (!camDef) return true;
-    if (cam.activeMount && cam.activeMount !== camDef.mount) {
-      return l.mount === cam.activeMount || l.mount === 'universal';
-    }
-    const mounts = new Set([camDef.mount, ...(camDef.adaptedMounts ?? [])]);
-    return mounts.has(l.mount) || l.mount === 'universal';
-  })];
+  const allCompat = [
+    ...compatLenses,
+    ...customLenses.filter((l) => !activeMount || l.mount === activeMount || l.mount === 'universal' || l.mount === 'integrated'),
+  ];
   // Deduplicate by id
   const compatDeduped = [...new Map(allCompat.map((l) => [l.id, l])).values()];
-  const grouped = groupByMount(sortFavoritesFirst(compatDeduped, favoriteLensIds));
+  // If the currently-selected lens is incompatible with the active mount (e.g.
+  // a B4 lens left over from an older project where FZ mode silently auto-
+  // applied the LA-FZB1), keep it visible in the dropdown so the user can see
+  // and fix it, but mark it as a mismatch.
+  const lensMismatch = !!(
+    lensDef && activeMount &&
+    lensDef.mount !== 'integrated' &&
+    lensDef.mount !== 'universal' &&
+    lensDef.mount !== activeMount
+  );
+  const dropdownLenses = lensMismatch && lensDef
+    ? [...compatDeduped, lensDef]
+    : compatDeduped;
+  const grouped = groupByMount(sortFavoritesFirst(dropdownLenses, favoriteLensIds));
   // Dedupe: when a built-in is shadowed (custom entry with the same id), only the
   // custom version appears in the dropdown — the built-in is hidden behind it.
   const customCameraIds = new Set(customCameras.map((c) => c.id));
@@ -142,6 +152,19 @@ function CameraCard({ camId }: { camId: string }) {
           title={adapterInfo.notes ?? 'Adapter automatically applied — see Mount section below for details.'}
         >
           ⚡ {adapterInfo.name}{adapterInfo.lightLossStops > 0 ? ` (−${adapterInfo.lightLossStops}T)` : ''}{adapterInfo.lightLossStops < 0 ? ` (+${Math.abs(adapterInfo.lightLossStops)}T gain)` : ''}{adapterInfo.cropSensor ? ` → ${adapterInfo.cropSensor.name}` : ''}
+        </div>
+      )}
+      {/* Lens-mount mismatch warning — the picked lens doesn't physically fit
+          the active mount. Calculations are computed against the body's bare
+          sensor (no auto-adapter), so the displayed values won't match reality
+          until the user either switches the Mount selector to the lens's mount
+          or picks a different lens. */}
+      {lensMismatch && lensDef && (
+        <div
+          className="text-xs mt-0.5 text-bc-red cursor-help"
+          title={`Switch the Mount selector below to "${lensDef.mount}" (if available) to fit the matching adapter / plate, or pick a lens that matches the current "${activeMount}" mount.`}
+        >
+          ⚠ Lens mount {lensDef.mount} ≠ active mount {activeMount} — incompatible
         </div>
       )}
       {/* Speed Booster toggle — only for EF lens on MFT camera */}
@@ -237,7 +260,11 @@ function CameraCard({ camId }: { camId: string }) {
                 if (e.target.value === '__new_custom__') { setShowNewCustomCam(true); return; }
                 const newCam = getCameraById(e.target.value, customCameras);
                 if (!newCam) return;
-                const lens = getCompatibleLenses(newCam.mount, newCam.adaptedMounts)[0];
+                // Pick a mount + first compatible lens. Falls back through the
+                // adaptedMounts list if the native mount has no compatible
+                // lenses (e.g. PMW-F5's FZ).
+                const pick = pickInitialMountAndLens(newCam.mount, newCam.adaptedMounts, customLenses);
+                const lens = pick.lens;
                 const supportsExtender = cam.extenderActive === 1 || !!lens?.extenderFactors?.includes(cam.extenderActive);
                 updateCamera(cam.id, {
                   cameraId: e.target.value,
@@ -245,12 +272,11 @@ function CameraCard({ camId }: { camId: string }) {
                   focalLength: lens?.focalLengthMin ?? cam.focalLength,
                   aperture: lens?.maxApertureWide ?? cam.aperture,
                   extenderActive: supportsExtender ? cam.extenderActive : 1,
-                  // Speedbooster only valid on MFT cameras with EF lenses
-                  useSpeedbooster: newCam.mount === 'MFT' && lens?.mount === 'EF' ? cam.useSpeedbooster : false,
+                  // Speedbooster only valid on MFT cameras with EF mount fitted
+                  useSpeedbooster: newCam.mount === 'MFT' && pick.mount === 'EF' ? cam.useSpeedbooster : false,
                   // Reset hardware sensor mode — each body has a different mode list
                   sensorModeIndex: newCam.sensorModes && newCam.sensorModes.length > 0 ? 0 : undefined,
-                  // Reset active mount to the new body's native mount
-                  activeMount: newCam.mount,
+                  activeMount: pick.mount,
                 });
               }}
             >

--- a/src/data/cameras.ts
+++ b/src/data/cameras.ts
@@ -62,7 +62,9 @@ export const CAMERAS: Camera[] = [
   // ── Canon Broadcast / Cinema ──
   { id: 'canon-c500ii', manufacturer: 'Canon', model: 'C500 Mark II', sensor: SENSORS.FF, mount: 'EF', resolutions: ['5.9K', '4K', 'HD'], type: 'cinema' },
   { id: 'canon-c300iii', manufacturer: 'Canon', model: 'C300 Mark III', sensor: SENSORS.S35, mount: 'EF', resolutions: ['4K', 'HD'], type: 'cinema' },
-  { id: 'canon-c70', manufacturer: 'Canon', model: 'C70', sensor: SENSORS.S35, mount: 'RF', resolutions: ['4K', 'HD'], type: 'cinema' },
+  { id: 'canon-c70', manufacturer: 'Canon', model: 'C70', sensor: SENSORS.S35, mount: 'RF', adaptedMounts: ['EF'], resolutions: ['4K', 'HD'], type: 'cinema', mountAdapters: {
+    EF: { name: 'Canon EF→RF Mount Adapter', lightLossStops: 0, notes: 'Passive Canon-official EF-to-RF adapter (also third-party clones). Mechanical extension only — full electronic compatibility with EF lenses, no light loss.' },
+  } },
   { id: 'canon-xf605', manufacturer: 'Canon', model: 'XF605', sensor: SENSORS.ONE_INCH, mount: 'integrated', resolutions: ['4K', 'HD'], type: 'camcorder' },
   { id: 'canon-cr-n500', manufacturer: 'Canon', model: 'CR-N500', sensor: SENSORS.ONE_INCH, mount: 'integrated', resolutions: ['4K', 'HD'], type: 'ptz' },
   { id: 'canon-cr-n300', manufacturer: 'Canon', model: 'CR-N300', sensor: SENSORS.HALF_INCH, mount: 'integrated', resolutions: ['4K', 'HD'], type: 'ptz' },
@@ -101,7 +103,10 @@ export const CAMERAS: Camera[] = [
   { id: 'bmd-pocket6kpro', manufacturer: 'Blackmagic', model: 'Pocket Cinema 6K Pro', sensor: SENSORS.S35, mount: 'EF', resolutions: ['6K', '4K', 'HD'], type: 'cinema' },
   { id: 'bmd-pocket6k', manufacturer: 'Blackmagic', model: 'Pocket Cinema 6K G2', sensor: SENSORS.S35, mount: 'EF', resolutions: ['6K', '4K', 'HD'], type: 'cinema' },
   { id: 'bmd-pocket4k', manufacturer: 'Blackmagic', model: 'Pocket Cinema 4K', sensor: SENSORS.MFT, mount: 'MFT', resolutions: ['4K', 'HD'], type: 'cinema' },
-  { id: 'bmd-cinema-camera-6k', manufacturer: 'Blackmagic', model: 'Cinema Camera 6K', sensor: SENSORS.FF, mount: 'L', resolutions: ['6K', '4K', 'HD'], type: 'cinema', notes: 'Full-frame, Leica L-mount' },
+  { id: 'bmd-cinema-camera-6k', manufacturer: 'Blackmagic', model: 'Cinema Camera 6K', sensor: SENSORS.FF, mount: 'L', adaptedMounts: ['EF', 'PL'], resolutions: ['6K', '4K', 'HD'], type: 'cinema', notes: 'Full-frame, Leica L-mount', mountAdapters: {
+    EF: { name: 'EF → L Adapter', lightLossStops: 0, notes: 'Passive EF-to-L adapter (Sigma MC-21, Novoflex, etc.). Mechanical only — full-frame sensor area available, no light loss.' },
+    PL: { name: 'PL → L Adapter', lightLossStops: 0, notes: 'Passive PL-to-L adapter. PL has a longer flange distance than L, so an empty barrel fits between them. No optical penalty.' },
+  } },
   { id: 'bmd-pyxis-6k', manufacturer: 'Blackmagic', model: 'PYXIS 6K', sensor: SENSORS.FF, mount: 'L', adaptedMounts: ['PL', 'EF'], resolutions: ['6K', '4K', 'HD'], type: 'cinema', notes: 'Full-frame box-style, L-mount native', mountAdapters: {
     PL: { name: 'PYXIS PL Mount (interchangeable)', lightLossStops: 0, notes: 'Passive PL mount block for the PYXIS 6K. Mechanical change only — full-frame 6K sensor area is used either way.' },
     EF: { name: 'PYXIS EF Mount (interchangeable)', lightLossStops: 0, notes: 'Passive EF mount block for the PYXIS 6K. Electronic aperture control is supported. No optical penalty.' },
@@ -148,79 +153,36 @@ export function getCamerasByType(type: Camera['type']): Camera[] {
 }
 
 /**
- * Determine if an adapter is needed and its effects.
+ * Determine the adapter currently fitted on the camera, if any.
  *
- * Priority:
- *   1. Body-defined adapter for the active mount (`camera.mountAdapters[active]`).
- *      Covers cases like the Sony PMW-F5 with the LA-FZB1 fitted, or the URSA
- *      Broadcast G2's built-in B4 relay — even though `lens.mount === activeMount`
- *      there's still real optical impact from the mount plate itself.
- *   2. Lens-based adapter for a lens whose mount differs from the active mount
- *      (e.g. a B4 lens on a Sony FX6 in E-mount mode → B4→E relay).
- *
- * `activeMount` overrides the camera's native mount for the purpose of adapter
- * detection. This models swappable-mount bodies like the URSA Broadcast G2 —
- * with the EF mount plate fitted, an EF lens is native (no adapter), and the
- * built-in 2/3" relay crop that comes with the B4 plate no longer applies.
+ * Strict model:
+ *   - The user picks the mount plate via the camera's Mount selector
+ *     (`VenueCamera.activeMount`). Whatever adapter is needed to convert from
+ *     `camera.mount` to `activeMount` is described in
+ *     `camera.mountAdapters[activeMount]`.
+ *   - The lens MUST match `activeMount`. There is no automatic "you picked a
+ *     B4 lens so we'll assume you also fitted the LA-FZB1" — that path made
+ *     the calculator silently apply optical penalties the user never opted
+ *     into. Lens-mount mismatches are surfaced as an incompatibility warning
+ *     in the UI instead.
+ *   - Speedbooster is a special EF→MFT focal reducer that swaps in for the
+ *     passive EF mount plate on MFT bodies. When `useSpeedbooster` is on and
+ *     the body is MFT with EF as the active mount, the Speedbooster info
+ *     supersedes the body's mountAdapter entry.
  */
-export function getAdapterInfo(camera: Camera, lens: Lens, useSpeedbooster = false, activeMount?: string): AdapterInfo | null {
+export function getAdapterInfo(camera: Camera, _lens: Lens, useSpeedbooster = false, activeMount?: string): AdapterInfo | null {
   const effectiveMount = activeMount ?? camera.mount;
 
-  // 1. Speedbooster takes precedence — it's a real EF→MFT relay regardless of
-  // any per-mount info.
-  if (useSpeedbooster && lens.mount === 'EF' && effectiveMount === 'MFT') {
+  if (useSpeedbooster && camera.mount === 'MFT' && effectiveMount === 'EF') {
     return {
       name: 'Metabones EF→MFT Speed Booster 0.71×',
       lightLossStops: -1.0,
       cropSensor: { name: 'MFT + Speed Booster (S35 equiv)', widthMm: 17.3 / 0.71, heightMm: 13 / 0.71, cropFactor: 2.0 * 0.71 },
-      notes: 'Focal reducer: widens FOV by 0.71×, gains ~1 T-stop of light, and the effective image area approaches Super-35.',
+      notes: 'Focal reducer that replaces the passive EF→MFT plate. Widens FOV by 0.71×, gains ~1 T-stop of light, and the effective image area approaches Super-35.',
     };
   }
 
-  // 2. Body-defined mount adapter — the LA-FZB1 on PMW-F5/F55 in B4 mode,
-  // URSA Broadcast G2 with the B4 mount plate (built-in relay), URSA Mini Pro
-  // with its EF plate, VENICE with the supplied E-mount, etc.
-  const mountAdapter = camera.mountAdapters?.[effectiveMount];
-
-  if (lens.mount === effectiveMount) return mountAdapter ?? null;
-  if (lens.mount === 'integrated') return mountAdapter ?? null;
-
-  // B4 → any larger-sensor camera: relay optics needed, crop to 2/3", ~1T loss.
-  // Real-world products: Sony LA-FZB1/FZB2 (for FZ-mount Sony cinema), MTF
-  // Services B4→PL/EF, Abakus B4→E-mount, IBE Optics B4→PL, etc. All work the
-  // same way — relay group, B4 lens projects a 2/3" image circle onto the
-  // sensor with ~1 T-stop loss.
-  if (lens.mount === 'B4') {
-    if (effectiveMount === 'FZ') return { name: 'Sony LA-FZB1/FZB2', lightLossStops: 1.0, cropSensor: SENSORS.TWO_THIRD, notes: 'Relay adapter with internal 2× optics. B4 lens projects a 2/3" image circle, crops the FZ Super-35 sensor to the 2/3" area, ~1 T-stop loss.' };
-    if (effectiveMount === 'E') return { name: 'B4 → E-mount Adapter (relay)', lightLossStops: 1.0, cropSensor: SENSORS.TWO_THIRD, notes: 'Generic B4→E relay adapter (e.g. Abakus 1097, MTF Services). Crops to 2/3" image area, ~1 T-stop loss through the relay glass.' };
-    if (effectiveMount === 'PL') return { name: 'B4 → PL Adapter (relay)', lightLossStops: 1.0, cropSensor: SENSORS.TWO_THIRD, notes: 'Relay adapter (e.g. IBE Optics B4→PL, MTF Services). 2/3" effective image area, ~1 T-stop loss.' };
-    if (effectiveMount === 'EF') return { name: 'B4 → EF Adapter (relay)', lightLossStops: 1.0, cropSensor: SENSORS.TWO_THIRD, notes: 'Relay adapter for EF-mount bodies. Crops to 2/3" area, ~1 T-stop loss.' };
-    return mountAdapter ?? null;
-  }
-
-  // PL → shorter flange mounts (spacer adapters, no optics)
-  if (lens.mount === 'PL') {
-    if (effectiveMount === 'FZ') return { name: 'PL → FZ Adapter', lightLossStops: 0, notes: 'Passive mechanical spacer. PL has a longer flange distance than FZ, so an empty barrel keeps the lens at the right distance. No optical penalty.' };
-    if (effectiveMount === 'E') return { name: 'PL → E-mount Adapter', lightLossStops: 0, notes: 'Passive mechanical adapter (e.g. Metabones PL→E, Wooden Camera, IBE Optics). PL flange distance is longer than E, so an empty barrel works without any glass.' };
-    if (effectiveMount === 'RF') return { name: 'PL → RF Adapter', lightLossStops: 0, notes: 'Passive mechanical PL-to-RF adapter. No optical penalty; full sensor area available.' };
-    return mountAdapter ?? null;
-  }
-
-  // EF → shorter flange mounts (Speedbooster case is handled at the top).
-  if (lens.mount === 'EF') {
-    if (effectiveMount === 'E') return { name: 'EF → E-mount Adapter', lightLossStops: 0, notes: 'Passive EF-to-E adapter (e.g. Metabones Mark V, Sigma MC-11). Mechanical only; some models pass aperture/AF data electronically. No optical penalty.' };
-    if (effectiveMount === 'RF') return { name: 'Canon EF → RF Adapter', lightLossStops: 0, notes: 'Canon\'s official EF→RF mount adapter (or third-party equivalents). Pure mechanical extension, no glass, full electronic compatibility.' };
-    if (effectiveMount === 'MFT') return { name: 'EF → MFT Adapter', lightLossStops: 0, notes: 'Standard passive EF-to-MFT adapter — manual aperture control only on most models. For light gain and wider FOV, enable Speed Booster instead.' };
-    return mountAdapter ?? null;
-  }
-
-  // Nikon F → shorter flange mounts
-  if (lens.mount === 'NF') {
-    if (effectiveMount === 'E') return { name: 'Nikon F → E-mount Adapter', lightLossStops: 0, notes: 'Passive Nikon-F to E-mount adapter. Manual aperture only on screwdriver-AF lenses; G/E lenses need an aperture-control variant.' };
-    return mountAdapter ?? null;
-  }
-
-  return null;
+  return camera.mountAdapters?.[effectiveMount] ?? null;
 }
 
 /**

--- a/src/data/lenses.ts
+++ b/src/data/lenses.ts
@@ -256,17 +256,46 @@ export function getLensesByMount(mount: string): Lens[] {
   return LENSES.filter((l) => l.mount === mount);
 }
 
-export function getCompatibleLenses(cameraMount: string, adaptedMounts?: string[], activeMount?: string): Lens[] {
+/**
+ * Returns the set of lenses that can physically attach to the camera given the
+ * currently fitted mount plate. The mount is determined as `activeMount` if the
+ * user has explicitly selected one, otherwise `cameraMount` (the body's native
+ * mount).
+ *
+ * IMPORTANT: this is strict. We do NOT auto-include lenses for other mounts
+ * (e.g. B4 lenses for an FZ-native PMW-F5) just because `adaptedMounts` lists
+ * them — those mounts are the *menu of plates the user can switch to*, not
+ * lenses mountable simultaneously. Picking a B4 lens on a PMW-F5 requires the
+ * user to first switch the Mount selector to "B4 (LA-FZB1)".
+ *
+ * `universal` and `integrated` lenses are returned unconditionally because they
+ * either have no mount (PTZ integrated) or are intentionally cross-mount stubs.
+ */
+export function getCompatibleLenses(cameraMount: string, _adaptedMounts?: string[], activeMount?: string): Lens[] {
   if (cameraMount === 'integrated') return LENSES.filter((l) => l.mount === 'integrated');
+  const target = activeMount ?? cameraMount;
+  return LENSES.filter((l) => l.mount === target || l.mount === 'universal' || l.mount === 'integrated');
+}
 
-  // When the user has explicitly swapped to a non-native mount plate (e.g. an
-  // URSA Broadcast G2 in EF mode), only lenses matching that mount can physically
-  // attach — the adaptedMounts list is the menu of plates available, not lenses
-  // mountable simultaneously.
-  if (activeMount && activeMount !== cameraMount) {
-    return LENSES.filter((l) => l.mount === activeMount || l.mount === 'integrated');
+/**
+ * Pick a sensible default mount + first matching lens for placing a camera or
+ * switching to a different body. Tries the camera's native mount first, then
+ * each entry in `adaptedMounts`, until it finds a mount with at least one
+ * compatible lens. For a Sony PMW-F5 — which has zero FZ-native lenses in the
+ * built-in DB — this falls back to PL (with the passive PL plate fitted) or
+ * B4 (with the LA-FZB1) instead of dropping the user into an empty dropdown.
+ */
+export function pickInitialMountAndLens(
+  cameraMount: string,
+  adaptedMounts?: string[],
+  extraLenses: Lens[] = [],
+): { mount: string; lens: Lens | undefined } {
+  const candidates = [cameraMount, ...(adaptedMounts ?? [])];
+  for (const m of candidates) {
+    const builtIn = getCompatibleLenses(cameraMount, adaptedMounts, m)[0];
+    const custom = extraLenses.find((l) => l.mount === m || l.mount === 'universal' || l.mount === 'integrated');
+    const lens = builtIn ?? custom;
+    if (lens) return { mount: m, lens };
   }
-
-  const mounts = new Set([cameraMount, ...(adaptedMounts ?? [])]);
-  return LENSES.filter((l) => mounts.has(l.mount) || l.mount === 'integrated');
+  return { mount: cameraMount, lens: undefined };
 }

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { VenueCamera, Venue, ViewTab, ReferencePerson, BackgroundPlan, Stage, ProjectFile, VenueTemplate, StageObjectType, Lens, Wall, Camera } from '../types';
 import { CAMERAS, CAMERA_COLORS } from '../data/cameras';
-import { LENSES } from '../data/lenses';
+import { LENSES, pickInitialMountAndLens } from '../data/lenses';
 import { TEMPLATES } from '../data/templates';
 
 // Injected by Vite from package.json. In a release build that came through
@@ -392,10 +392,17 @@ export const useStore = create<AppState>((set, get) => ({
       const cam = cameraId ? CAMERAS.find((c) => c.id === cameraId) : CAMERAS[0];
       const camDef = cam ?? CAMERAS[0];
       const allLenses = [...LENSES, ...s.customLenses];
-      const lens = lensId
-        ? allLenses.find((l) => l.id === lensId)
-        : allLenses.find((l) => l.mount === camDef.mount) ?? allLenses[0];
-      const lensDef = lens ?? allLenses[0];
+      // If a specific lens was requested, honour it. Otherwise pick a default
+      // mount + lens combination that's actually usable (e.g. PMW-F5 has zero
+      // FZ-native lenses, so we default to PL instead of dropping the user
+      // into an empty dropdown).
+      let activeMount = camDef.mount;
+      let lensDef = lensId ? allLenses.find((l) => l.id === lensId) : undefined;
+      if (!lensDef) {
+        const pick = pickInitialMountAndLens(camDef.mount, camDef.adaptedMounts, s.customLenses);
+        activeMount = pick.mount;
+        lensDef = pick.lens ?? allLenses[0];
+      }
       const idx = s.cameras.length;
       const newCam: VenueCamera = {
         id: uid(),
@@ -414,7 +421,7 @@ export const useStore = create<AppState>((set, get) => ({
         extenderActive: 1,
         useSpeedbooster: false,
         sensorModeIndex: camDef.sensorModes && camDef.sensorModes.length > 0 ? 0 : undefined,
-        activeMount: camDef.mount,
+        activeMount,
       };
       return { cameras: [...s.cameras, newCam], selectedCameraId: newCam.id, projectVersion: s.projectVersion + 1 };
     });


### PR DESCRIPTION
Sony PMW-F5 with activeMount=FZ + B4 lens used to silently apply the LA-FZB1 relay (cropping the sensor to 2/3" and shaving 1 T-stop) even though the user never said "I have the LA-FZB1 fitted". The calculator showed a B4-with-relay result while the Mount selector still claimed "FZ (native)". Same trap on the URSA Broadcast G2, PMW-F55, and every other body where the lens-mount-mismatch path in getAdapterInfo could fire.

New model — strict:

  - Lens must match the body's CURRENTLY FITTED mount plate (`VenueCamera.activeMount`). The mount selector is the single source of truth for which adapter is in use.
  - `getCompatibleLenses` returns only lenses whose mount equals the active mount (plus integrated / universal). The previous "native + adaptedMounts union" union let cross-mount lenses sneak in.
  - `getAdapterInfo` no longer infers an adapter from a lens-mount mismatch. The only adapters returned are the body-defined `mountAdapters[activeMount]` and the EF→MFT Speedbooster when explicitly enabled. A lens whose mount doesn't match the active mount triggers an "incompatible" warning instead of a free LA-FZB1.

UX consequences:

  - The PMW-F5 default activeMount=FZ has zero compatible lenses in the DB. `pickInitialMountAndLens` now walks [camera.mount, ...adaptedMounts] in order and picks the first mount that has any lens, so adding a PMW-F5 drops the user onto the PL mount with a PL lens preselected — usable, not empty.
  - Camera-switch and addCamera both go through the helper so activeMount is whatever has a lens, not blindly the native.
  - Sidebar shows a red "⚠ Lens mount X ≠ active mount Y — incompatible" pill when the persisted lens doesn't fit. The mismatched lens stays visible in the dropdown so the user can see what's selected, but the FOV/DoF calc uses the body's bare sensor (no adapter), which makes the incompatibility audibly wrong rather than silently wrong.

Audit pass for cameras with native mounts that have no DB lenses:
  - Canon C70 (RF native): added adaptedMounts ['EF'] with passive Canon EF→RF Mount Adapter entry — fallback picks EF.
  - BMD Cinema Camera 6K (L native): added adaptedMounts ['EF', 'PL'] with passive adapter entries — fallback picks EF.
  - Marshall CV568 (M12): left as-is — POV cam, M12 cinema lenses are out of scope; user can model one via Custom+ if needed.

All other built-in cameras already had a compatible mount choice under the strict filter.

https://claude.ai/code/session_01G3jsVfY5KunJPGk5Q8xjEr