### PR TITLE
fix(security): comprehensive audit fixes — CSP, export registry, test…

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high || true
+
       - name: Sync package.json version with the release tag
         # electron-builder names artifacts (e.g. "MultiCam Planner Setup X.Y.Z.exe")
         # using the version field in package.json — NOT the git tag. Without this

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,5 +1,7 @@
-const { app, BrowserWindow, shell } = require('electron');
+const { app, BrowserWindow, shell, session } = require('electron');
 const path = require('path');
+
+const ALLOWED_EXTERNAL_PROTOCOLS = ['https:', 'mailto:'];
 
 function createMainWindow() {
   const mainWindow = new BrowserWindow({
@@ -9,10 +11,6 @@ function createMainWindow() {
     minHeight: 720,
     autoHideMenuBar: true,
     backgroundColor: '#0f1117',
-    // Window icon for dev mode + Linux taskbar. On Windows/macOS the packaged
-    // build also embeds the icon via electron-builder's build.win.icon /
-    // build.mac.icon config, but setting it here makes `npm run desktop` show
-    // the right icon too.
     icon: path.join(__dirname, '..', 'build', 'icon.png'),
     webPreferences: {
       contextIsolation: true,
@@ -24,8 +22,32 @@ function createMainWindow() {
   mainWindow.loadFile(indexPath);
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    try {
+      const parsed = new URL(url);
+      if (ALLOWED_EXTERNAL_PROTOCOLS.includes(parsed.protocol)) {
+        shell.openExternal(url);
+      }
+    } catch { /* malformed URL — ignore */ }
     return { action: 'deny' };
+  });
+
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!url.startsWith('file://')) {
+      event.preventDefault();
+    }
+  });
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
+          "img-src 'self' data: blob:; connect-src 'self' https://generativelanguage.googleapis.com; " +
+          "font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+        ],
+      },
+    });
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://generativelanguage.googleapis.com; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MultiCam Planner – Broadcast Camera &amp; Lens Planning</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9",
         "typescript-eslint": "^8.59.3",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2193,6 +2194,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2270,6 +2278,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2279,6 +2298,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
@@ -2734,6 +2760,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -3082,6 +3221,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -3466,6 +3615,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4267,6 +4426,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4541,6 +4707,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4549,6 +4725,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -5741,6 +5927,16 @@
         "three": ">=0.134.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -6176,6 +6372,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6279,6 +6486,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7136,6 +7350,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -7236,6 +7457,13 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -7270,6 +7498,13 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -7563,6 +7798,23 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7609,6 +7861,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -8029,6 +8291,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webgl-constants": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
@@ -8053,6 +8418,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dist:win": "npm run build && electron-builder --win --publish never",
     "dist:mac": "npm run build && electron-builder --mac --x64 --arm64 --publish never",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "build": {
     "appId": "com.larszu.multicamplanner",
@@ -101,6 +103,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9",
     "typescript-eslint": "^8.59.3",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^4.1.8"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import CameraPreview from './components/Preview/CameraPreview';
 import Calculator from './components/Sidebar/Calculator';
 import TemplateSelector from './components/Templates/TemplateSelector';
 import ExportPanel from './components/Export/ExportPanel';
+import ErrorBoundary from './components/ErrorBoundary';
+import { getExportRegistry } from './store/exportRegistry';
+import { loadJSON, saveJSON } from './utils/storage';
 import { Suspense, useState, useRef, useCallback, useEffect } from 'react';
 import { FiChevronLeft, FiChevronRight, FiMaximize2, FiMinimize2, FiMinus, FiX } from 'react-icons/fi';
 import { Layout, Model, TabNode, Actions } from 'flexlayout-react';
@@ -130,11 +133,7 @@ function createGridLayoutJson(): IJsonModel {
 }
 
 function loadUserLayoutPresets(): Record<string, IJsonModel> {
-  try {
-    return JSON.parse(localStorage.getItem(LAYOUT_PRESETS_KEY) ?? '{}') as Record<string, IJsonModel>;
-  } catch {
-    return {};
-  }
+  return loadJSON<Record<string, IJsonModel>>(LAYOUT_PRESETS_KEY, {});
 }
 
 function LoadingFallback() {
@@ -149,9 +148,11 @@ function LoadingFallback() {
 function useLayoutModel() {
   return useState(() => {
     try {
-      const saved = localStorage.getItem(LAYOUT_STORAGE_KEY);
       const savedVersion = Number(localStorage.getItem(LAYOUT_VERSION_KEY) ?? '0');
-      if (saved && savedVersion === CURRENT_LAYOUT_VERSION) return Model.fromJson(JSON.parse(saved));
+      if (savedVersion === CURRENT_LAYOUT_VERSION) {
+        const saved = loadJSON<IJsonModel | null>(LAYOUT_STORAGE_KEY, null);
+        if (saved) return Model.fromJson(saved);
+      }
     } catch { /* ignore corrupt data */ }
     return Model.fromJson(createFocusLayoutJson());
   });
@@ -168,10 +169,8 @@ export default function App() {
   const layoutRef = useRef<Layout>(null);
 
   const persistLayout = useCallback((nextModel: Model) => {
-    try {
-      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(nextModel.toJson()));
-      localStorage.setItem(LAYOUT_VERSION_KEY, String(CURRENT_LAYOUT_VERSION));
-    } catch { /* quota exceeded etc */ }
+    saveJSON(LAYOUT_STORAGE_KEY, nextModel.toJson());
+    saveJSON(LAYOUT_VERSION_KEY, CURRENT_LAYOUT_VERSION);
   }, []);
 
   const applyLayoutJson = useCallback((json: IJsonModel) => {
@@ -231,18 +230,14 @@ export default function App() {
     };
 
     setUserLayoutPresets(nextPresets);
-    try {
-      localStorage.setItem(LAYOUT_PRESETS_KEY, JSON.stringify(nextPresets));
-    } catch { /* quota exceeded etc */ }
+    saveJSON(LAYOUT_PRESETS_KEY, nextPresets);
   }, [model, userLayoutPresets]);
 
   const handleDeleteLayoutPreset = useCallback((presetId: string) => {
     const nextPresets = { ...userLayoutPresets };
     delete nextPresets[presetId];
     setUserLayoutPresets(nextPresets);
-    try {
-      localStorage.setItem(LAYOUT_PRESETS_KEY, JSON.stringify(nextPresets));
-    } catch { /* quota exceeded etc */ }
+    saveJSON(LAYOUT_PRESETS_KEY, nextPresets);
   }, [userLayoutPresets]);
 
 
@@ -380,24 +375,15 @@ export default function App() {
     return () => mq.removeEventListener('change', handler);
   }, [setSidebarCollapsed]);
 
-  // ── Expose layout-prep hook for the export panel ──
-  // Capturing each panel requires it to be visible at non-zero size. In Focus mode
-  // only one tab is rendered visibly, so we switch to Grid for the duration of the
-  // export and restore the previous layout afterwards.
   useEffect(() => {
-    (window as any).__multicamPrepareForExport = async () => {
+    const registry = getExportRegistry();
+    registry.prepareForExport = async () => {
       const previousMode = layoutMode;
       const previousFocusTab = focusTabId;
       const previousModelJson = model.toJson();
       if (previousMode !== 'grid') {
         applyLayoutJson(createGridLayoutJson());
         setLayoutMode('grid');
-        // Wait long enough for FlexLayout to mount the new tabsets, for
-        // ResizeObservers to fire on each panel container, and for Konva/R3F to
-        // paint at least one frame at the new dimensions. R3F in particular needs
-        // multiple paint cycles after a fresh resize before its WebGL drawing
-        // buffer holds the visible scene — bumping to ~700ms avoids the first
-        // capture coming out as an empty/black 3D tile.
         await new Promise<void>((resolve) => {
           requestAnimationFrame(() => requestAnimationFrame(() => {
             setTimeout(resolve, 700);
@@ -417,10 +403,11 @@ export default function App() {
         },
       };
     };
-    return () => { delete (window as any).__multicamPrepareForExport; };
+    return () => { registry.prepareForExport = null; };
   }, [applyLayoutJson, focusTabId, layoutMode, model]);
 
   return (
+    <ErrorBoundary>
     <div className="h-screen flex flex-col bg-bc-dark text-gray-200">
       <Header
         onSelectTab={handleSelectTab}
@@ -481,5 +468,6 @@ export default function App() {
 
       <ExportPanel />
     </div>
+    </ErrorBoundary>
   );
 }

--- a/src/__tests__/camera.test.ts
+++ b/src/__tests__/camera.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveCameraPos } from '../utils/camera';
+import type { VenueCamera } from '../types';
+
+function makeCam(overrides: Partial<VenueCamera> = {}): VenueCamera {
+  return {
+    id: 'cam-1',
+    label: 'CAM 1',
+    cameraId: 'test',
+    lensId: 'test',
+    x: 10,
+    y: 5,
+    z: 1.5,
+    pan: 0,
+    tilt: 0,
+    focalLength: 50,
+    aperture: 5.6,
+    focusDistance: 10,
+    color: '#ff0000',
+    extenderActive: 1,
+    ...overrides,
+  };
+}
+
+describe('effectiveCameraPos', () => {
+  it('returns parked position when no offset', () => {
+    const cam = makeCam();
+    const pos = effectiveCameraPos(cam);
+    expect(pos.x).toBe(10);
+    expect(pos.y).toBe(5);
+  });
+
+  it('returns parked position when trackOffset is 0', () => {
+    const cam = makeCam({ trackOffset: 0 });
+    const pos = effectiveCameraPos(cam);
+    expect(pos.x).toBe(10);
+    expect(pos.y).toBe(5);
+  });
+
+  it('offsets along pan=0 (rightward)', () => {
+    const cam = makeCam({ pan: 0, trackOffset: 2 });
+    const pos = effectiveCameraPos(cam);
+    expect(pos.x).toBeCloseTo(12, 5);
+    expect(pos.y).toBeCloseTo(5, 5);
+  });
+
+  it('offsets along pan=90 (downward)', () => {
+    const cam = makeCam({ pan: 90, trackOffset: 3 });
+    const pos = effectiveCameraPos(cam);
+    expect(pos.x).toBeCloseTo(10, 5);
+    expect(pos.y).toBeCloseTo(8, 5);
+  });
+
+  it('offsets along pan=-90 (upward)', () => {
+    const cam = makeCam({ pan: -90, trackOffset: 2 });
+    const pos = effectiveCameraPos(cam);
+    expect(pos.x).toBeCloseTo(10, 5);
+    expect(pos.y).toBeCloseTo(3, 5);
+  });
+
+  it('handles negative trackOffset', () => {
+    const cam = makeCam({ pan: 0, trackOffset: -2 });
+    const pos = effectiveCameraPos(cam);
+    expect(pos.x).toBeCloseTo(8, 5);
+    expect(pos.y).toBeCloseTo(5, 5);
+  });
+});

--- a/src/__tests__/fov.test.ts
+++ b/src/__tests__/fov.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  horizontalFov,
+  verticalFov,
+  diagonalFov,
+  imageWidthAtDistance,
+  imageHeightAtDistance,
+  equivalentFocalLength,
+  computeFov,
+  circleOfConfusion,
+  hyperfocalDistance,
+  computeDof,
+  personHeightInFrame,
+  fovConePoints,
+} from '../utils/fov';
+import type { SensorSize } from '../types';
+
+const FF_SENSOR: SensorSize = { name: 'Full Frame', widthMm: 36, heightMm: 24, cropFactor: 1 };
+const S35_SENSOR: SensorSize = { name: 'Super 35', widthMm: 24.89, heightMm: 14, cropFactor: 1.74 };
+const TWO_THIRDS_SENSOR: SensorSize = { name: '2/3"', widthMm: 8.8, heightMm: 6.6, cropFactor: 5.0 };
+
+describe('horizontalFov', () => {
+  it('returns correct FOV for a full-frame 50mm lens', () => {
+    const fov = horizontalFov(36, 50);
+    expect(fov).toBeCloseTo(39.6, 1);
+  });
+
+  it('returns wider FOV for shorter focal length', () => {
+    const wide = horizontalFov(36, 24);
+    const tele = horizontalFov(36, 200);
+    expect(wide).toBeGreaterThan(tele);
+  });
+
+  it('returns 0 for infinite focal length conceptually', () => {
+    const fov = horizontalFov(36, 100000);
+    expect(fov).toBeCloseTo(0, 1);
+  });
+});
+
+describe('verticalFov', () => {
+  it('returns correct vertical FOV', () => {
+    const fov = verticalFov(24, 50);
+    expect(fov).toBeCloseTo(27.0, 1);
+  });
+});
+
+describe('diagonalFov', () => {
+  it('is always >= horizontal and vertical', () => {
+    const d = diagonalFov(36, 24, 50);
+    const h = horizontalFov(36, 50);
+    const v = verticalFov(24, 50);
+    expect(d).toBeGreaterThan(h);
+    expect(d).toBeGreaterThan(v);
+  });
+});
+
+describe('imageWidthAtDistance', () => {
+  it('doubles when distance doubles', () => {
+    const w5 = imageWidthAtDistance(36, 50, 5);
+    const w10 = imageWidthAtDistance(36, 50, 10);
+    expect(w10).toBeCloseTo(w5 * 2, 2);
+  });
+
+  it('returns a reasonable width at 10m for 50mm FF', () => {
+    const w = imageWidthAtDistance(36, 50, 10);
+    expect(w).toBeGreaterThan(5);
+    expect(w).toBeLessThan(10);
+  });
+});
+
+describe('imageHeightAtDistance', () => {
+  it('scales linearly with distance', () => {
+    const h1 = imageHeightAtDistance(24, 50, 1);
+    const h3 = imageHeightAtDistance(24, 50, 3);
+    expect(h3 / h1).toBeCloseTo(3, 2);
+  });
+});
+
+describe('equivalentFocalLength', () => {
+  it('equals focal length for crop factor 1', () => {
+    expect(equivalentFocalLength(50, 1)).toBe(50);
+  });
+
+  it('multiplies correctly', () => {
+    expect(equivalentFocalLength(50, 1.5)).toBe(75);
+  });
+});
+
+describe('computeFov', () => {
+  it('applies extender multiplication', () => {
+    const noExt = computeFov(FF_SENSOR, 50, 10, 1);
+    const with2x = computeFov(FF_SENSOR, 50, 10, 2);
+    expect(with2x.horizontalDeg).toBeLessThan(noExt.horizontalDeg);
+    expect(with2x.equivalentFocalLength).toBeCloseTo(noExt.equivalentFocalLength * 2, 1);
+  });
+
+  it('returns consistent image dimensions', () => {
+    const fov = computeFov(S35_SENSOR, 35, 10, 1);
+    expect(fov.imageWidthAtDistance).toBeGreaterThan(0);
+    expect(fov.imageHeightAtDistance).toBeGreaterThan(0);
+    expect(fov.imageWidthAtDistance).toBeGreaterThan(fov.imageHeightAtDistance);
+  });
+
+  it('handles 2/3" broadcast sensor', () => {
+    const fov = computeFov(TWO_THIRDS_SENSOR, 8, 10, 1);
+    expect(fov.horizontalDeg).toBeGreaterThan(20);
+    expect(fov.horizontalDeg).toBeLessThan(90);
+  });
+});
+
+describe('circleOfConfusion', () => {
+  it('returns standard value for full frame (~0.029mm)', () => {
+    const coc = circleOfConfusion(36, 24);
+    expect(coc).toBeCloseTo(0.029, 2);
+  });
+
+  it('returns smaller CoC for smaller sensors', () => {
+    const cocFF = circleOfConfusion(36, 24);
+    const cocS35 = circleOfConfusion(24.89, 14);
+    expect(cocS35).toBeLessThan(cocFF);
+  });
+});
+
+describe('hyperfocalDistance', () => {
+  it('returns a finite positive value', () => {
+    const h = hyperfocalDistance(50, 5.6, 0.029);
+    expect(h).toBeGreaterThan(0);
+    expect(isFinite(h)).toBe(true);
+  });
+
+  it('increases with focal length', () => {
+    const h50 = hyperfocalDistance(50, 5.6, 0.029);
+    const h100 = hyperfocalDistance(100, 5.6, 0.029);
+    expect(h100).toBeGreaterThan(h50);
+  });
+});
+
+describe('computeDof', () => {
+  it('returns near < focus < far', () => {
+    const dof = computeDof(FF_SENSOR, 50, 5.6, 5, 1);
+    expect(dof.nearLimit).toBeLessThan(5);
+    expect(dof.farLimit).toBeGreaterThan(5);
+  });
+
+  it('wider aperture = shallower DoF', () => {
+    const dofWide = computeDof(FF_SENSOR, 85, 1.4, 3, 1);
+    const dofNarrow = computeDof(FF_SENSOR, 85, 11, 3, 1);
+    expect(dofWide.totalDof).toBeLessThan(dofNarrow.totalDof);
+  });
+
+  it('short focal length increases DoF', () => {
+    const dofShort = computeDof(FF_SENSOR, 24, 5.6, 5, 1);
+    const dofLong = computeDof(FF_SENSOR, 200, 5.6, 5, 1);
+    expect(dofShort.totalDof).toBeGreaterThan(dofLong.totalDof);
+  });
+
+  it('can return infinity for far limit', () => {
+    const dof = computeDof(FF_SENSOR, 24, 11, 10, 1);
+    expect(dof.farLimit).toBe(Infinity);
+  });
+
+  it('applies extender to DoF', () => {
+    const noExt = computeDof(FF_SENSOR, 50, 5.6, 5, 1);
+    const with2x = computeDof(FF_SENSOR, 50, 5.6, 5, 2);
+    expect(with2x.totalDof).toBeLessThan(noExt.totalDof);
+  });
+});
+
+describe('personHeightInFrame', () => {
+  it('person fills more of frame at closer distance', () => {
+    const pxClose = personHeightInFrame(24, 50, 3);
+    const pxFar = personHeightInFrame(24, 50, 20);
+    expect(pxClose).toBeGreaterThan(pxFar);
+  });
+
+  it('returns positive value', () => {
+    const px = personHeightInFrame(24, 50, 10);
+    expect(px).toBeGreaterThan(0);
+  });
+
+  it('longer focal length shows person larger', () => {
+    const px50 = personHeightInFrame(24, 50, 10);
+    const px200 = personHeightInFrame(24, 200, 10);
+    expect(px200).toBeGreaterThan(px50);
+  });
+});
+
+describe('fovConePoints', () => {
+  it('returns symmetric points for 0 rotation', () => {
+    const pts = fovConePoints(0, 0, 0, 60, 10);
+    expect(pts.left.y).toBeCloseTo(-pts.right.y, 5);
+    expect(pts.left.x).toBeCloseTo(pts.right.x, 5);
+  });
+
+  it('returns points at the correct range', () => {
+    const pts = fovConePoints(0, 0, 90, 40, 5);
+    const distL = Math.sqrt(pts.left.x ** 2 + pts.left.y ** 2);
+    const distR = Math.sqrt(pts.right.x ** 2 + pts.right.y ** 2);
+    expect(distL).toBeCloseTo(5, 5);
+    expect(distR).toBeCloseTo(5, 5);
+  });
+});

--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadJSON, saveJSON } from '../utils/storage';
+
+const store: Record<string, string> = {};
+
+beforeEach(() => {
+  for (const key of Object.keys(store)) delete store[key];
+
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+  });
+});
+
+describe('loadJSON', () => {
+  it('returns fallback when key is missing', () => {
+    expect(loadJSON('missing', [])).toEqual([]);
+  });
+
+  it('parses stored JSON', () => {
+    store['test'] = JSON.stringify({ a: 1 });
+    expect(loadJSON('test', {})).toEqual({ a: 1 });
+  });
+
+  it('returns fallback on corrupt JSON', () => {
+    store['bad'] = 'not json{{{';
+    expect(loadJSON('bad', 'default')).toBe('default');
+  });
+});
+
+describe('saveJSON', () => {
+  it('stores JSON string', () => {
+    saveJSON('key', [1, 2, 3]);
+    expect(store['key']).toBe('[1,2,3]');
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Uncaught error in React tree:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: 32, color: '#ef4444', background: '#0f1117', minHeight: '100vh' }}>
+          <h1 style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 12 }}>Something went wrong</h1>
+          <p style={{ color: '#9ca3af', marginBottom: 16 }}>
+            The application encountered an unexpected error. Try refreshing the page.
+          </p>
+          <pre style={{ fontSize: 12, color: '#6b7280', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {this.state.error?.message}
+          </pre>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              marginTop: 16, padding: '8px 20px', background: '#3b82f6', color: '#fff',
+              border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: 14,
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/Export/ExportPanel.tsx
+++ b/src/components/Export/ExportPanel.tsx
@@ -3,6 +3,7 @@ import { useStore, APP_VERSION } from '../../store/useStore';
 import { getCameraById, getEffectiveSensor, getAdapterInfo } from '../../data/cameras';
 import { getLensById } from '../../data/lenses';
 import { computeFov, computeDof, personHeightInFrame } from '../../utils/fov';
+import { getExportRegistry } from '../../store/exportRegistry';
 import type { VenueCamera } from '../../types';
 
 export type ExportMode = 'current' | 'all' | 'widetele' | 'all-widetele';
@@ -27,10 +28,10 @@ export default function ExportPanel() {
   const { cameras, selectedCameraId, venue, projectVersion } = useStore();
 
   const capture2DCanvas = useCallback((): HTMLCanvasElement | null => {
-    const capture = (window as any).__capture2DExport;
-    if (typeof capture === 'function') {
+    const registry = getExportRegistry();
+    if (typeof registry.capture2DExport === 'function') {
       try {
-        return capture() as HTMLCanvasElement | null;
+        return registry.capture2DExport();
       } catch { /* fall through */ }
     }
     return document.querySelector('.konvajs-content canvas') as HTMLCanvasElement | null;
@@ -49,9 +50,9 @@ export default function ExportPanel() {
   }, []);
 
   const capturePreviewCanvas = useCallback((): HTMLCanvasElement | null => {
-    const fn = (window as any).__capturePreviewCanvas;
-    if (typeof fn === 'function') {
-      try { return fn() as HTMLCanvasElement | null; } catch { /* fall through */ }
+    const registry = getExportRegistry();
+    if (typeof registry.capturePreviewCanvas === 'function') {
+      try { return registry.capturePreviewCanvas(); } catch { /* fall through */ }
     }
     return null;
   }, []);
@@ -349,25 +350,17 @@ export default function ExportPanel() {
 
     setExporting(true);
 
-    // Prepare layout (force Grid so all panels render at proper size)
     let restoreLayout: (() => void) | null = null;
-    const prepFn = (window as any).__multicamPrepareForExport as
-      | (() => Promise<{ restore: () => void } | null>)
-      | undefined;
-    if (typeof prepFn === 'function') {
+    const registry = getExportRegistry();
+    if (typeof registry.prepareForExport === 'function') {
       try {
-        const prep = await prepFn();
+        const prep = await registry.prepareForExport();
         if (prep) restoreLayout = prep.restore;
       } catch { /* fall through */ }
     }
 
-    // Frame the 3D view on the venue so the exported tile shows the whole stage
-    // area instead of whatever free-fly angle the user happened to leave it on.
-    // The previous camera state is saved and restored after the batch.
-    const framingApi = (window as any).__multicam3DFraming as
-      | { save: () => any; apply: (s: any) => void; fitVenue: (w: number, h: number) => void }
-      | undefined;
-    let savedFraming: any = null;
+    const framingApi = registry.framing3D;
+    let savedFraming: import('../../store/exportRegistry').FramingState | null = null;
     if (framingApi) {
       try {
         savedFraming = framingApi.save();

--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -3,6 +3,7 @@ import { getCameraById, getEffectiveSensor, getAdapterInfo } from '../../data/ca
 import { getLensById } from '../../data/lenses';
 import { computeFov, computeDof } from '../../utils/fov';
 import { effectiveCameraPos } from '../../utils/camera';
+import { getExportRegistry } from '../../store/exportRegistry';
 import { useRef, useEffect, useLayoutEffect, useCallback, useState } from 'react';
 import type { StageObjectType } from '../../types';
 import { FiChevronLeft, FiChevronRight, FiUnlock, FiLock } from 'react-icons/fi';
@@ -834,7 +835,8 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   }, [draw]);
 
   useEffect(() => {
-    (window as any).__capturePreviewCanvas = () => {
+    const registry = getExportRegistry();
+    registry.capturePreviewCanvas = () => {
       const source = canvasRef.current;
       if (!source || source.width === 0 || source.height === 0) return null;
 
@@ -847,9 +849,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       return copy;
     };
 
-    return () => {
-      delete (window as any).__capturePreviewCanvas;
-    };
+    return () => { registry.capturePreviewCanvas = null; };
   }, []);
 
   // ── PTZ Mouse Controls ──

--- a/src/components/Sidebar/CustomCameraForm.tsx
+++ b/src/components/Sidebar/CustomCameraForm.tsx
@@ -150,14 +150,14 @@ export function CustomCameraForm({ initial, onSubmit, onCancel, submitLabel = 'C
       const prompt = buildPrompt(manufacturer, model);
       const data = await callGemini(apiKey, prompt);
       applyAiResult(data);
-    } catch (err: any) {
-      setAiError(err?.message ?? 'AI request failed');
+    } catch (err: unknown) {
+      setAiError(err instanceof Error ? err.message : 'AI request failed');
     } finally {
       setAiLoading(false);
     }
   };
 
-  const applyAiResult = (data: any) => {
+  const applyAiResult = (data: GeminiCameraResult) => {
     if (data.manufacturer && !manufacturer.trim()) setManufacturer(String(data.manufacturer));
     if (data.model && !model.trim()) setModel(String(data.model));
     if (typeof data.mount === 'string' && data.mount.trim()) {
@@ -165,12 +165,12 @@ export function CustomCameraForm({ initial, onSubmit, onCancel, submitLabel = 'C
       setMount(m);
       setMountIsCustom(!(MOUNTS as readonly string[]).includes(m));
     }
-    if (data.type && TYPES.some((t) => t.value === data.type)) setType(data.type);
+    if (data.type && TYPES.some((t) => t.value === data.type)) setType(data.type as Camera['type']);
     if (Array.isArray(data.adaptedMounts)) {
       setAdaptedMounts(
         data.adaptedMounts
-          .filter((m: any) => typeof m === 'string' && m.trim().length > 0)
-          .map((m: string) => m.trim()),
+          .filter((m): m is string => typeof m === 'string' && m.trim().length > 0)
+          .map((m) => m.trim()),
       );
     }
     if (data.sensor && typeof data.sensor.widthMm === 'number' && typeof data.sensor.heightMm === 'number') {
@@ -182,8 +182,9 @@ export function CustomCameraForm({ initial, onSubmit, onCancel, submitLabel = 'C
     if (Array.isArray(data.sensorModes)) {
       setModes(
         data.sensorModes
-          .filter((m: any) => m && typeof m.widthMm === 'number' && typeof m.heightMm === 'number')
-          .map((m: any) => ({
+          .filter((m): m is { name?: string; widthMm: number; heightMm: number } =>
+            !!m && typeof m.widthMm === 'number' && typeof m.heightMm === 'number')
+          .map((m) => ({
             name: String(m.name ?? ''),
             widthMm: String(m.widthMm),
             heightMm: String(m.heightMm),
@@ -536,11 +537,21 @@ function buildPrompt(manufacturer: string, model: string): string {
   ].join('\n');
 }
 
-async function callGemini(apiKey: string, prompt: string): Promise<any> {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${encodeURIComponent(apiKey)}`;
+interface GeminiCameraResult {
+  manufacturer?: string;
+  model?: string;
+  sensor?: { name?: string; widthMm: number; heightMm: number };
+  mount?: string;
+  adaptedMounts?: string[];
+  type?: string;
+  sensorModes?: { name?: string; widthMm: number; heightMm: number }[];
+}
+
+async function callGemini(apiKey: string, prompt: string): Promise<GeminiCameraResult> {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
   const response = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
     body: JSON.stringify({
       contents: [{ role: 'user', parts: [{ text: prompt }] }],
       generationConfig: {
@@ -554,13 +565,17 @@ async function callGemini(apiKey: string, prompt: string): Promise<any> {
     throw new Error(`Gemini ${response.status}: ${text.slice(0, 200) || response.statusText}`);
   }
   const data = await response.json();
-  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+  const text: string | undefined = data?.candidates?.[0]?.content?.parts?.[0]?.text;
   if (!text) throw new Error('Gemini returned an empty response');
+  let parsed: unknown;
   try {
-    return JSON.parse(text);
+    parsed = JSON.parse(text);
   } catch {
-    // Some responses include code fences even with responseMimeType=application/json
     const stripped = text.replace(/^```(?:json)?/i, '').replace(/```\s*$/, '').trim();
-    return JSON.parse(stripped);
+    parsed = JSON.parse(stripped);
   }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('Gemini returned a non-object response');
+  }
+  return parsed as GeminiCameraResult;
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -857,13 +857,22 @@ export default function Sidebar() {
   const [autoResize, setAutoResize] = useState(true);
   const [scaleLocked, setScaleLocked] = useState(true);
 
+  const MAX_PDF_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+  const MAX_PDF_PAGES = 100;
+
   /** Convert a PDF first page to a data URL at 2× DPI */
   const pdfToDataUrl = useCallback(async (file: File): Promise<{ dataUrl: string; width: number; height: number }> => {
+    if (file.size > MAX_PDF_SIZE_BYTES) {
+      throw new Error(`PDF too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum is 50 MB.`);
+    }
     pdfjsLib.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
     const arrayBuf = await file.arrayBuffer();
-    const pdf = await pdfjsLib.getDocument({ data: arrayBuf }).promise;
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuf, isEvalSupported: false } as Parameters<typeof pdfjsLib.getDocument>[0]).promise;
+    if (pdf.numPages > MAX_PDF_PAGES) {
+      throw new Error(`PDF has ${pdf.numPages} pages (max ${MAX_PDF_PAGES}). Use a single-page floor plan.`);
+    }
     const page = await pdf.getPage(1);
-    const scale = 2; // 2× for crisp rendering
+    const scale = 2;
     const viewport = page.getViewport({ scale });
     const canvas = document.createElement('canvas');
     canvas.width = viewport.width;
@@ -896,8 +905,8 @@ export default function Sidebar() {
         };
         setBackgroundPlan(plan);
       } catch (err) {
-        alert('Failed to render PDF. Make sure it is a valid PDF file.');
-        console.error(err);
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        alert(`Failed to render PDF: ${msg}`);
       }
     } else {
       const reader = new FileReader();

--- a/src/components/Venue2D/Venue2D.tsx
+++ b/src/components/Venue2D/Venue2D.tsx
@@ -6,6 +6,7 @@ import { computeFov } from '../../utils/fov';
 import type { VenueCamera, Wall } from '../../types';
 import { MOUNT_HEIGHT_RANGE } from '../../types';
 import { effectiveCameraPos } from '../../utils/camera';
+import { getExportRegistry } from '../../store/exportRegistry';
 import React, { useRef, useCallback, useEffect, useState } from 'react';
 import type Konva from 'konva';
 
@@ -79,11 +80,9 @@ export default function Venue2D() {
   const worldW = Math.max(W, bgExtentW);
   const worldH = Math.max(H, bgExtentH);
 
-  // Expose stage ref and venue pixel dims for export capture
   useEffect(() => {
-    (window as any).__konvaStage = stageRef.current;
-    (window as any).__konvaVenueSize = { w: worldW, h: worldH };
-    (window as any).__capture2DExport = () => {
+    const registry = getExportRegistry();
+    registry.capture2DExport = () => {
       const stage = stageRef.current;
       if (!stage) return null;
       try {
@@ -98,11 +97,7 @@ export default function Venue2D() {
         return null;
       }
     };
-    return () => {
-      (window as any).__konvaStage = null;
-      (window as any).__konvaVenueSize = null;
-      delete (window as any).__capture2DExport;
-    };
+    return () => { registry.capture2DExport = null; };
   }, [worldW, worldH]);
 
   // Measure container and auto-fit zoom

--- a/src/components/Venue3D/Venue3D.tsx
+++ b/src/components/Venue3D/Venue3D.tsx
@@ -7,6 +7,8 @@ import { getLensById } from '../../data/lenses';
 import { computeFov } from '../../utils/fov';
 import { effectiveCameraPos } from '../../utils/camera';
 import * as THREE from 'three';
+import { getExportRegistry } from '../../store/exportRegistry';
+import type { FramingState } from '../../store/exportRegistry';
 import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 import type { BackgroundPlan, StageObjectType } from '../../types';
 
@@ -25,7 +27,7 @@ function DraggableOnFloor({ children, x, z, onDragEnd, onClick }: {
 
   const handlePointerDown = useCallback((e: any) => {
     e.stopPropagation();
-    (e.target as any).setPointerCapture?.(e.pointerId);
+    (e.target as Element).setPointerCapture?.(e.pointerId);
     isDragging.current = true;
     // Calculate offset between pointer hit and group position
     const raycaster = e.ray ? new THREE.Raycaster(e.ray.origin, e.ray.direction) : null;
@@ -49,7 +51,7 @@ function DraggableOnFloor({ children, x, z, onDragEnd, onClick }: {
   const handlePointerUp = useCallback((e: any) => {
     if (!isDragging.current) return;
     isDragging.current = false;
-    (e.target as any).releasePointerCapture?.(e.pointerId);
+    (e.target as Element).releasePointerCapture?.(e.pointerId);
     if (groupRef.current && onDragEnd) {
       onDragEnd(groupRef.current.position.x, groupRef.current.position.z);
     }
@@ -176,24 +178,20 @@ function FPSControls({ mouseLookEnabled }: { mouseLookEnabled: boolean }) {
     return () => window.removeEventListener('multicam-3d-reset', handleReset);
   }, [camera]);
 
-  // Expose a framing API for the export panel: save the current camera, frame the
-  // entire venue with a downward angle that fits the canvas, and restore later.
   useEffect(() => {
-    (window as any).__multicam3DFraming = {
-      save: () => ({
+    const registry = getExportRegistry();
+    registry.framing3D = {
+      save: (): FramingState => ({
         pos: camera.position.toArray() as [number, number, number],
         yaw: yaw.current,
         pitch: pitch.current,
       }),
-      apply: (state: { pos: [number, number, number]; yaw: number; pitch: number }) => {
+      apply: (state: FramingState) => {
         camera.position.fromArray(state.pos);
         yaw.current = state.yaw;
         pitch.current = state.pitch;
       },
       fitVenue: (widthM: number, heightM: number) => {
-        // Position the camera above-behind the venue and aim at the floor centre.
-        // The result is a 3/4 overview where the whole stage area is visible
-        // even with the canvas constrained to the export tile's 16:9 ratio.
         const diag = Math.sqrt(widthM * widthM + heightM * heightM);
         const camX = widthM / 2;
         const camY = diag * 0.55;
@@ -210,7 +208,7 @@ function FPSControls({ mouseLookEnabled }: { mouseLookEnabled: boolean }) {
         pitch.current = Math.atan2(dy, horizDist);
       },
     };
-    return () => { delete (window as any).__multicam3DFraming; };
+    return () => { registry.framing3D = null; };
   }, [camera]);
 
   useEffect(() => {

--- a/src/store/exportRegistry.ts
+++ b/src/store/exportRegistry.ts
@@ -1,0 +1,27 @@
+export interface ExportRegistry {
+  capture2DExport: (() => HTMLCanvasElement | null) | null;
+  capturePreviewCanvas: (() => HTMLCanvasElement | null) | null;
+  prepareForExport: (() => Promise<{ restore: () => void } | null>) | null;
+  framing3D: {
+    save: () => FramingState;
+    apply: (s: FramingState) => void;
+    fitVenue: (w: number, h: number) => void;
+  } | null;
+}
+
+export interface FramingState {
+  pos: [number, number, number];
+  yaw: number;
+  pitch: number;
+}
+
+const registry: ExportRegistry = {
+  capture2DExport: null,
+  capturePreviewCanvas: null,
+  prepareForExport: null,
+  framing3D: null,
+};
+
+export function getExportRegistry(): ExportRegistry {
+  return registry;
+}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -3,6 +3,7 @@ import type { VenueCamera, Venue, ViewTab, ReferencePerson, BackgroundPlan, Stag
 import { CAMERAS, CAMERA_COLORS } from '../data/cameras';
 import { LENSES, pickInitialMountAndLens } from '../data/lenses';
 import { TEMPLATES } from '../data/templates';
+import { loadJSON, saveJSON } from '../utils/storage';
 
 // Injected by Vite from package.json. In a release build that came through
 // the GitHub Actions workflow this matches the git release tag exactly,
@@ -104,64 +105,47 @@ function uid(prefix = 'cam'): string {
 
 const CUSTOM_TEMPLATES_KEY = 'multicam-custom-templates';
 function loadCustomTemplates(): VenueTemplate[] {
-  try {
-    const raw = localStorage.getItem(CUSTOM_TEMPLATES_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch { return []; }
+  return loadJSON<VenueTemplate[]>(CUSTOM_TEMPLATES_KEY, []);
 }
 function saveCustomTemplates(templates: VenueTemplate[]) {
-  localStorage.setItem(CUSTOM_TEMPLATES_KEY, JSON.stringify(templates));
+  saveJSON(CUSTOM_TEMPLATES_KEY, templates);
 }
 
 const HIDDEN_TEMPLATES_KEY = 'multicam-hidden-templates';
 function loadHiddenTemplateIds(): string[] {
-  try {
-    const raw = localStorage.getItem(HIDDEN_TEMPLATES_KEY);
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
-  } catch { return []; }
+  const parsed = loadJSON<string[]>(HIDDEN_TEMPLATES_KEY, []);
+  return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
 }
 function saveHiddenTemplateIds(ids: string[]) {
-  localStorage.setItem(HIDDEN_TEMPLATES_KEY, JSON.stringify(ids));
+  saveJSON(HIDDEN_TEMPLATES_KEY, ids);
 }
 
 const CUSTOM_LENSES_KEY = 'multicam-custom-lenses';
 function loadCustomLenses(): Lens[] {
-  try {
-    const raw = localStorage.getItem(CUSTOM_LENSES_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch { return []; }
+  return loadJSON<Lens[]>(CUSTOM_LENSES_KEY, []);
 }
 function saveCustomLensesStorage(lenses: Lens[]) {
-  localStorage.setItem(CUSTOM_LENSES_KEY, JSON.stringify(lenses));
+  saveJSON(CUSTOM_LENSES_KEY, lenses);
 }
 
 const CUSTOM_CAMERAS_KEY = 'multicam-custom-cameras';
 function loadCustomCameras(): Camera[] {
-  try {
-    const raw = localStorage.getItem(CUSTOM_CAMERAS_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch { return []; }
+  return loadJSON<Camera[]>(CUSTOM_CAMERAS_KEY, []);
 }
 function saveCustomCamerasStorage(cameras: Camera[]) {
-  localStorage.setItem(CUSTOM_CAMERAS_KEY, JSON.stringify(cameras));
+  saveJSON(CUSTOM_CAMERAS_KEY, cameras);
 }
 
 const FAVORITE_CAMERAS_KEY = 'multicam-favorite-cameras';
 const FAVORITE_LENSES_KEY = 'multicam-favorite-lenses';
 
 function loadFavoriteIds(key: string): string[] {
-  try {
-    const raw = localStorage.getItem(key);
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [];
-  } catch {
-    return [];
-  }
+  const parsed = loadJSON<string[]>(key, []);
+  return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [];
 }
 
 function saveFavoriteIds(key: string, ids: string[]) {
-  localStorage.setItem(key, JSON.stringify(ids));
+  saveJSON(key, ids);
 }
 
 let stageId = 1;
@@ -671,13 +655,12 @@ export const useStore = create<AppState>((set, get) => ({
       useSpeedbooster: c.useSpeedbooster ?? false,
       mountType: c.mountType ?? 'tripod',
     }));
-    // Migrate old single-scale background plans to scaleX/scaleY
     let bgPlan = project.backgroundPlan;
     if (bgPlan && 'scale' in bgPlan && !('scaleX' in bgPlan)) {
-      const s = (bgPlan as any).scale as number;
-      const { ...rest } = bgPlan as any;
-      delete rest.scale;
-      bgPlan = { ...rest, scaleX: s, scaleY: s } as BackgroundPlan;
+      const legacy = bgPlan as BackgroundPlan & { scale?: number };
+      const s = legacy.scale ?? 1;
+      const { scale: _, ...rest } = legacy;
+      bgPlan = { ...rest, scaleX: s, scaleY: s };
     }
     set({
       venue: project.venue,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,14 @@
+export function loadJSON<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) as T : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveJSON(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch { /* quota exceeded */ }
+}


### PR DESCRIPTION
…s, hardening

- Add Content-Security-Policy meta tag and Electron session CSP injection (SEC-1)
- Move Gemini API key from URL query param to x-goog-api-key header (SEC-3)
- Add PDF file-size and page-count limits with isEvalSupported:false (SEC-4)
- Type Gemini AI response with GeminiCameraResult interface, remove `any` (SEC-5)
- Restrict shell.openExternal to https:/mailto: schemes, block will-navigate (SEC-6)
- Replace all window.* global function bus with typed ExportRegistry (ARC-2)
- Add React ErrorBoundary at app root (Error Handling)
- Extract loadJSON/saveJSON storage helpers, deduplicate 8 localStorage patterns (ARC-4)
- Fix `as any` escapes in useStore bgPlan migration and Venue3D pointer capture (AI-2)
- Add vitest with 37 unit tests covering FOV, DoF, camera position, and storage utils (AI-3)
- Add npm audit step to CI workflow (OPS-2)
- Replace console.error with user-facing error messages in PDF handler

https://claude.ai/code/session_01HdFCt2U9iiGktUKWxdiFHw