### PR TITLE
feat(2d): Settings tab + sidebar reorder (#44), stage resize handles (#42), object context menu (#38)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -429,7 +429,7 @@ export default function App() {
               className={`flex-1 py-2 text-xs font-medium ${sidebarTab === 'cameras' ? 'text-bc-accent border-b-2 border-bc-accent' : 'text-gray-500 hover:text-gray-300'}`}
               onClick={() => setSidebarTab('cameras')}
             >
-              Cameras
+              Settings
             </button>
             <button
               className={`flex-1 py-2 text-xs font-medium ${sidebarTab === 'templates' ? 'text-bc-accent border-b-2 border-bc-accent' : 'text-gray-500 hover:text-gray-300'}`}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1074,126 +1074,6 @@ export default function Sidebar() {
         )}
       </div>
 
-      {/* Persons & Stage Objects */}
-      <div className="p-3 border-b border-bc-border">
-        <button
-          className="flex items-center justify-between w-full text-sm text-white font-semibold"
-          onClick={() => setPersonsOpen(!personsOpen)}
-        >
-          <span><FiUser className="inline mr-1" size={13} />Objects & Persons ({persons.length})</span>
-          {personsOpen ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
-        </button>
-        {personsOpen && (
-          <div className="mt-2 space-y-2 text-xs">
-            {persons.map((p) => {
-              const icon =
-                p.objectType === 'drums' ? '🥁' :
-                p.objectType === 'keys' ? '🎹' :
-                p.objectType === 'person-guitar' ? '🎸' :
-                p.objectType === 'mic-stand' ? '🎤' :
-                p.objectType === 'sitting-person' ? '🪑' :
-                p.objectType === 'chair' ? '💺' :
-                p.objectType === 'table' ? '🪑' :
-                p.objectType === 'lectern' ? '🎙️' :
-                p.objectType === 'schneetiger' ? '🐅' :
-                p.objectType === 'custom' ? '◇' : '👤';
-              return (
-                <div key={p.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
-                  <span className="text-gray-500 text-[10px] w-6 text-center">{icon}</span>
-                  <input className="bg-transparent text-white text-xs w-16 outline-none" value={p.label}
-                    onChange={(e) => updatePerson(p.id, { label: e.target.value })} />
-                  <span className="text-gray-500">{p.height}m</span>
-                  <input
-                    type="color"
-                    className="w-5 h-5 rounded border border-bc-border cursor-pointer bg-transparent"
-                    value={p.color ?? (OBJECT_PRESETS[p.objectType]?.color ?? '#f59e0b')}
-                    onChange={(e) => updatePerson(p.id, { color: e.target.value })}
-                    title="Custom accent colour"
-                  />
-                  <span className="text-gray-500">({p.x.toFixed(1)}, {p.y.toFixed(1)})</span>
-                  <button onClick={() => removePerson(p.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
-                </div>
-              );
-            })}
-            <div className="grid grid-cols-3 gap-1">
-              <button onClick={() => addPerson()} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                <FiUser size={10} /> Person
-              </button>
-              <button onClick={() => addStageObject('person-guitar')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🎸 Guitarist
-              </button>
-              <button onClick={() => addStageObject('sitting-person')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🪑 Seated
-              </button>
-              <button onClick={() => addStageObject('drums')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🥁 Drums
-              </button>
-              <button onClick={() => addStageObject('keys')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🎹 Keys
-              </button>
-              <button onClick={() => addStageObject('mic-stand')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🎤 Mic Stand
-              </button>
-              <button onClick={() => addStageObject('chair')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                💺 Chair
-              </button>
-              <button onClick={() => addStageObject('table')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🟫 Table
-              </button>
-              <button onClick={() => addStageObject('lectern')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
-                🎙️ Lectern
-              </button>
-              <button onClick={() => addStageObject('schneetiger')} className="col-span-3 flex items-center justify-center gap-1 px-1 py-1 rounded bg-sky-500/20 text-sky-300 text-[10px] hover:bg-sky-500/30">
-                🐅 Schneetiger
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Walls */}
-      <div className="p-3 border-b border-bc-border">
-        <button
-          className="flex items-center justify-between w-full text-sm text-white font-semibold"
-          onClick={() => setWallsOpen(!wallsOpen)}
-        >
-          <span>▇ Walls ({walls.length})</span>
-          {wallsOpen ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
-        </button>
-        {wallsOpen && (
-          <div className="mt-2 space-y-2 text-xs">
-            <button
-              onClick={() => setWallDrawMode((active) => !active)}
-              className={`flex items-center gap-1 px-2 py-1 rounded text-xs w-full justify-center ${wallDrawMode ? 'bg-bc-yellow/20 text-bc-yellow hover:bg-bc-yellow/30' : 'bg-bc-dark text-gray-300 hover:text-white border border-bc-border'}`}
-            >
-              {wallDrawMode ? 'Stop Drawing' : 'Draw Walls'}
-            </button>
-            {wallDrawMode && (
-              <div className="rounded border border-bc-border bg-bc-dark px-2 py-1.5 text-[10px] text-gray-400 leading-relaxed">
-                Click once to place the start point, click again to finish. Hold Shift to snap the angle.
-              </div>
-            )}
-            {walls.map((w) => (
-              <div key={w.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
-                <input
-                  className="bg-transparent text-white text-xs w-16 outline-none"
-                  value={w.label}
-                  onChange={(e) => updateWall(w.id, { label: e.target.value })}
-                />
-                <span className="text-gray-500 text-[10px]">{w.height}m h</span>
-                <button onClick={() => removeWall(w.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
-              </div>
-            ))}
-            <button
-              onClick={() => addWall()}
-              className="flex items-center gap-1 px-2 py-1 rounded bg-bc-accent/20 text-bc-accent text-xs hover:bg-bc-accent/30 w-full justify-center"
-            >
-              <FiPlus size={12} /> Add Wall
-            </button>
-          </div>
-        )}
-      </div>
-
       {/* Background plan */}
       <div className="p-3 border-b border-bc-border">
         <button
@@ -1338,6 +1218,126 @@ export default function Sidebar() {
         )}
       </div>
 
+
+      {/* Walls */}
+      <div className="p-3 border-b border-bc-border">
+        <button
+          className="flex items-center justify-between w-full text-sm text-white font-semibold"
+          onClick={() => setWallsOpen(!wallsOpen)}
+        >
+          <span>▇ Walls ({walls.length})</span>
+          {wallsOpen ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
+        </button>
+        {wallsOpen && (
+          <div className="mt-2 space-y-2 text-xs">
+            <button
+              onClick={() => setWallDrawMode((active) => !active)}
+              className={`flex items-center gap-1 px-2 py-1 rounded text-xs w-full justify-center ${wallDrawMode ? 'bg-bc-yellow/20 text-bc-yellow hover:bg-bc-yellow/30' : 'bg-bc-dark text-gray-300 hover:text-white border border-bc-border'}`}
+            >
+              {wallDrawMode ? 'Stop Drawing' : 'Draw Walls'}
+            </button>
+            {wallDrawMode && (
+              <div className="rounded border border-bc-border bg-bc-dark px-2 py-1.5 text-[10px] text-gray-400 leading-relaxed">
+                Click once to place the start point, click again to finish. Hold Shift to snap the angle.
+              </div>
+            )}
+            {walls.map((w) => (
+              <div key={w.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
+                <input
+                  className="bg-transparent text-white text-xs w-16 outline-none"
+                  value={w.label}
+                  onChange={(e) => updateWall(w.id, { label: e.target.value })}
+                />
+                <span className="text-gray-500 text-[10px]">{w.height}m h</span>
+                <button onClick={() => removeWall(w.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
+              </div>
+            ))}
+            <button
+              onClick={() => addWall()}
+              className="flex items-center gap-1 px-2 py-1 rounded bg-bc-accent/20 text-bc-accent text-xs hover:bg-bc-accent/30 w-full justify-center"
+            >
+              <FiPlus size={12} /> Add Wall
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Persons & Stage Objects */}
+      <div className="p-3 border-b border-bc-border">
+        <button
+          className="flex items-center justify-between w-full text-sm text-white font-semibold"
+          onClick={() => setPersonsOpen(!personsOpen)}
+        >
+          <span><FiUser className="inline mr-1" size={13} />Objects & Persons ({persons.length})</span>
+          {personsOpen ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
+        </button>
+        {personsOpen && (
+          <div className="mt-2 space-y-2 text-xs">
+            {persons.map((p) => {
+              const icon =
+                p.objectType === 'drums' ? '🥁' :
+                p.objectType === 'keys' ? '🎹' :
+                p.objectType === 'person-guitar' ? '🎸' :
+                p.objectType === 'mic-stand' ? '🎤' :
+                p.objectType === 'sitting-person' ? '🪑' :
+                p.objectType === 'chair' ? '💺' :
+                p.objectType === 'table' ? '🪑' :
+                p.objectType === 'lectern' ? '🎙️' :
+                p.objectType === 'schneetiger' ? '🐅' :
+                p.objectType === 'custom' ? '◇' : '👤';
+              return (
+                <div key={p.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
+                  <span className="text-gray-500 text-[10px] w-6 text-center">{icon}</span>
+                  <input className="bg-transparent text-white text-xs w-16 outline-none" value={p.label}
+                    onChange={(e) => updatePerson(p.id, { label: e.target.value })} />
+                  <span className="text-gray-500">{p.height}m</span>
+                  <input
+                    type="color"
+                    className="w-5 h-5 rounded border border-bc-border cursor-pointer bg-transparent"
+                    value={p.color ?? (OBJECT_PRESETS[p.objectType]?.color ?? '#f59e0b')}
+                    onChange={(e) => updatePerson(p.id, { color: e.target.value })}
+                    title="Custom accent colour"
+                  />
+                  <span className="text-gray-500">({p.x.toFixed(1)}, {p.y.toFixed(1)})</span>
+                  <button onClick={() => removePerson(p.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
+                </div>
+              );
+            })}
+            <div className="grid grid-cols-3 gap-1">
+              <button onClick={() => addPerson()} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                <FiUser size={10} /> Person
+              </button>
+              <button onClick={() => addStageObject('person-guitar')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🎸 Guitarist
+              </button>
+              <button onClick={() => addStageObject('sitting-person')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🪑 Seated
+              </button>
+              <button onClick={() => addStageObject('drums')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🥁 Drums
+              </button>
+              <button onClick={() => addStageObject('keys')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🎹 Keys
+              </button>
+              <button onClick={() => addStageObject('mic-stand')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🎤 Mic Stand
+              </button>
+              <button onClick={() => addStageObject('chair')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                💺 Chair
+              </button>
+              <button onClick={() => addStageObject('table')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🟫 Table
+              </button>
+              <button onClick={() => addStageObject('lectern')} className="flex items-center justify-center gap-1 px-1 py-1 rounded bg-bc-accent/20 text-bc-accent text-[10px] hover:bg-bc-accent/30">
+                🎙️ Lectern
+              </button>
+              <button onClick={() => addStageObject('schneetiger')} className="col-span-3 flex items-center justify-center gap-1 px-1 py-1 rounded bg-sky-500/20 text-sky-300 text-[10px] hover:bg-sky-500/30">
+                🐅 Schneetiger
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Camera list */}
       <div className="flex-1 p-3 overflow-y-auto">

--- a/src/components/Venue2D/Venue2D.tsx
+++ b/src/components/Venue2D/Venue2D.tsx
@@ -1,4 +1,4 @@
-import { Stage, Layer, Rect, Wedge, Circle, Text, Group, Line, Image as KImage } from 'react-konva';
+import { Stage, Layer, Rect, Wedge, Circle, Text, Group, Line, Image as KImage, Transformer } from 'react-konva';
 import { useStore } from '../../store/useStore';
 import { getCameraById, getEffectiveSensor } from '../../data/cameras';
 import { getLensById } from '../../data/lenses';
@@ -9,15 +9,42 @@ import { effectiveCameraPos } from '../../utils/camera';
 import { getExportRegistry } from '../../store/exportRegistry';
 import React, { useRef, useCallback, useEffect, useState } from 'react';
 import type Konva from 'konva';
+import { FiCopy, FiLock, FiUnlock, FiTrash2 } from 'react-icons/fi';
+
+// Shared style for context-menu items (issue #38).
+const ctxItemStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  width: '100%',
+  padding: '6px 8px',
+  borderRadius: 6,
+  background: 'transparent',
+  border: 'none',
+  color: 'inherit',
+  cursor: 'pointer',
+  textAlign: 'left',
+  font: 'inherit',
+};
 
 export default function Venue2D() {
-  const { venue, setVenue, cameras, selectedCameraId, selectCamera, moveCamera, updateCamera, showAllFov, pixelsPerMeter, persons, updatePerson, updateStage, backgroundPlan, setBackgroundPlan, walls, updateWall, addWall } = useStore();
+  const { venue, setVenue, cameras, selectedCameraId, selectCamera, moveCamera, updateCamera, removeCamera, duplicateCamera, showAllFov, pixelsPerMeter, persons, updatePerson, removePerson, duplicatePerson, updateStage, addStage, removeStage, backgroundPlan, setBackgroundPlan, walls, updateWall, addWall } = useStore();
   const stageRef = useRef<Konva.Stage>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [bgImage, setBgImage] = useState<HTMLImageElement | null>(null);
   const [containerSize, setContainerSize] = useState({ w: 800, h: 600 });
   const [zoom, setZoom] = useState(1);
   const [stagePos, setStagePos] = useState({ x: 0, y: 0 });
+
+  // ── Stage resize (issue #42): select a stage to show a Konva Transformer
+  // with corner/edge anchors. ──
+  const [selectedStageId, setSelectedStageId] = useState<string | null>(null);
+  const trRef = useRef<Konva.Transformer>(null);
+  const stageNodeRefs = useRef<Record<string, Konva.Group>>({});
+
+  // ── Right-click context menu (issue #42/#38) ──
+  type MenuTarget = { x: number; y: number; kind: 'camera' | 'person' | 'stage'; id: string; locked: boolean };
+  const [menu, setMenu] = useState<MenuTarget | null>(null);
 
   // ── Wall drawing mode ──
   const [drawingWall, setDrawingWall] = useState(false);
@@ -192,6 +219,10 @@ export default function Venue2D() {
 
   // Handle calibration clicks on the stage
   const handleStageClick = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    // Clicking empty canvas (the Konva Stage itself) clears the stage selection.
+    if (e.target === e.target.getStage() && !drawingWall && !calibActive) {
+      setSelectedStageId(null);
+    }
     const point = getPointerWorldPoint();
     if (!point) return;
 
@@ -358,6 +389,103 @@ export default function Venue2D() {
     [updatePerson, ppm, venue],
   );
 
+  // Keep the Transformer attached to the currently-selected (unlocked) stage.
+  useEffect(() => {
+    const tr = trRef.current;
+    if (!tr) return;
+    const target = selectedStageId ? venue.stages.find((s) => s.id === selectedStageId) : null;
+    const node = selectedStageId ? stageNodeRefs.current[selectedStageId] : null;
+    if (node && target && !target.locked) {
+      tr.nodes([node]);
+    } else {
+      tr.nodes([]);
+    }
+    tr.getLayer()?.batchDraw();
+  }, [selectedStageId, venue.stages, drawingWall, calibActive]);
+
+  // Commit a Transformer resize: convert the scaled group back into metric
+  // width/height (+ x/y, since top/left anchors move the origin) and reset the
+  // scale so the next drag starts clean. Clamps to a 0.5 m minimum.
+  const handleStageTransformEnd = useCallback(
+    (stageId: string, e: Konva.KonvaEventObject<Event>) => {
+      const node = e.target;
+      const scaleX = node.scaleX();
+      const scaleY = node.scaleY();
+      node.scaleX(1);
+      node.scaleY(1);
+      const src = venue.stages.find((s) => s.id === stageId);
+      if (!src) return;
+      const newWidth = Math.max(0.5, src.width * scaleX);
+      const newHeight = Math.max(0.5, src.height * scaleY);
+      const newX = Math.max(0, node.x() / ppm);
+      const newY = Math.max(0, node.y() / ppm);
+      node.position({ x: newX * ppm, y: newY * ppm });
+      updateStage(stageId, {
+        x: newX,
+        y: newY,
+        width: Math.round(newWidth * 10) / 10,
+        height: Math.round(newHeight * 10) / 10,
+      });
+    },
+    [ppm, updateStage, venue.stages],
+  );
+
+  // Open the right-click context menu for an object, positioned at the cursor
+  // relative to the canvas container (issue #38).
+  const openContextMenu = useCallback(
+    (kind: MenuTarget['kind'], id: string, locked: boolean, e: Konva.KonvaEventObject<PointerEvent>) => {
+      e.evt.preventDefault();
+      e.cancelBubble = true;
+      const rect = containerRef.current?.getBoundingClientRect();
+      setMenu({
+        kind,
+        id,
+        locked,
+        x: e.evt.clientX - (rect?.left ?? 0),
+        y: e.evt.clientY - (rect?.top ?? 0),
+      });
+    },
+    [],
+  );
+
+  // Dismiss the context menu on any outside interaction / Escape.
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    const onKey = (ev: KeyboardEvent) => { if (ev.key === 'Escape') setMenu(null); };
+    window.addEventListener('mousedown', close);
+    window.addEventListener('wheel', close);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', close);
+      window.removeEventListener('wheel', close);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [menu]);
+
+  const handleMenuAction = useCallback((action: 'duplicate' | 'lock' | 'delete') => {
+    if (!menu) return;
+    const { kind, id, locked } = menu;
+    if (action === 'delete') {
+      if (kind === 'camera') removeCamera(id);
+      else if (kind === 'person') removePerson(id);
+      else { removeStage(id); if (selectedStageId === id) setSelectedStageId(null); }
+    } else if (action === 'lock') {
+      if (kind === 'camera') updateCamera(id, { locked: !locked });
+      else if (kind === 'person') updatePerson(id, { locked: !locked });
+      else { updateStage(id, { locked: !locked }); if (!locked && selectedStageId === id) setSelectedStageId(null); }
+    } else {
+      // duplicate
+      if (kind === 'camera') duplicateCamera(id);
+      else if (kind === 'person') duplicatePerson(id);
+      else {
+        const src = venue.stages.find((s) => s.id === id);
+        if (src) addStage({ x: Math.min(venue.widthM - src.width, src.x + 0.5), y: Math.min(venue.heightM - src.height, src.y + 0.5), width: src.width, height: src.height, label: `${src.label} copy` });
+      }
+    }
+    setMenu(null);
+  }, [menu, removeCamera, removePerson, removeStage, updateCamera, updatePerson, updateStage, duplicateCamera, duplicatePerson, addStage, venue.stages, venue.widthM, venue.heightM, selectedStageId]);
+
   return (
     <div ref={containerRef} style={{ width: '100%', height: '100%', background: '#0a0b0f', borderRadius: 8, overflow: 'hidden', position: 'relative' }}>
       {/* Zoom indicator */}
@@ -459,14 +587,39 @@ export default function Venue2D() {
           );
         })}
 
-        {/* Stages */}
+        {/* Stages — click to select (shows resize handles), drag to move,
+            right-click for the context menu (issue #42 / #38). */}
         {venue.stages.map((s) => (
-          <Group key={s.id} x={s.x * ppm} y={s.y * ppm} draggable={!drawingWall} onDragEnd={(e) => handleStageDragEnd(s.id, e)}>
-            <Rect width={s.width * ppm} height={s.height * ppm} fill="rgba(59,130,246,0.15)" stroke="#3b82f6" strokeWidth={2} cornerRadius={4} />
-            <Text x={4} y={4} text={s.label} fontSize={12} fill="#3b82f6" fontStyle="bold" />
+          <Group
+            key={s.id}
+            ref={(node) => { if (node) stageNodeRefs.current[s.id] = node; else delete stageNodeRefs.current[s.id]; }}
+            x={s.x * ppm}
+            y={s.y * ppm}
+            draggable={!drawingWall && !s.locked}
+            onDragEnd={(e) => handleStageDragEnd(s.id, e)}
+            onClick={(e) => { if (!drawingWall && !calibActive) { e.cancelBubble = true; setSelectedStageId(s.locked ? null : s.id); } }}
+            onTap={(e) => { if (!drawingWall && !calibActive) { e.cancelBubble = true; setSelectedStageId(s.locked ? null : s.id); } }}
+            onContextMenu={(e) => openContextMenu('stage', s.id, !!s.locked, e)}
+            onTransformEnd={(e) => handleStageTransformEnd(s.id, e)}
+          >
+            <Rect width={s.width * ppm} height={s.height * ppm} fill="rgba(59,130,246,0.15)" stroke={selectedStageId === s.id ? '#60a5fa' : '#3b82f6'} strokeWidth={selectedStageId === s.id ? 3 : 2} cornerRadius={4} />
+            <Text x={4} y={4} text={s.locked ? `${s.label} 🔒` : s.label} fontSize={12} fill="#3b82f6" fontStyle="bold" />
             <Text x={4} y={s.height * ppm - 16} text={`${s.width}×${s.height}m`} fontSize={9} fill="#3b82f688" />
           </Group>
         ))}
+        {/* Resize handles for the selected stage */}
+        <Transformer
+          ref={trRef}
+          rotateEnabled={false}
+          keepRatio={false}
+          ignoreStroke
+          anchorSize={8}
+          anchorStroke="#60a5fa"
+          anchorFill="#0f1117"
+          borderStroke="#60a5fa"
+          enabledAnchors={['top-left', 'top-right', 'bottom-left', 'bottom-right', 'middle-left', 'middle-right', 'top-center', 'bottom-center']}
+          boundBoxFunc={(oldBox, newBox) => (newBox.width < 8 || newBox.height < 8 ? oldBox : newBox)}
+        />
 
         {/* Walls */}
         {walls.map((w) => (
@@ -511,7 +664,7 @@ export default function Venue2D() {
           );
           const footW = Math.max(6, p.width * ppm);
           return (
-            <Group key={p.id} x={p.x * ppm} y={p.y * ppm} draggable onDragEnd={(e) => handlePersonDragEnd(p.id, e)}>
+            <Group key={p.id} x={p.x * ppm} y={p.y * ppm} draggable={!p.locked} onDragEnd={(e) => handlePersonDragEnd(p.id, e)} onContextMenu={(e) => openContextMenu('person', p.id, !!p.locked, e)}>
               {type === 'table' || type === 'drums' || type === 'keys' ? (
                 <Rect x={-footW / 2} y={-footW / 4} width={footW} height={footW / 2} fill={col} opacity={0.55} stroke={col} strokeWidth={1} cornerRadius={2} />
               ) : type === 'schneetiger' ? (
@@ -519,7 +672,7 @@ export default function Venue2D() {
               ) : (
                 <Circle radius={Math.max(5, footW / 3)} fill={col} stroke="#fff" strokeWidth={1} opacity={0.85} />
               )}
-              <Text x={-26} y={8} text={`${p.label} (${p.height}m)`} fontSize={9} fill={col} align="center" width={52} />
+              <Text x={-26} y={8} text={`${p.locked ? '🔒 ' : ''}${p.label} (${p.height}m)`} fontSize={9} fill={col} align="center" width={52} />
             </Group>
           );
         })}
@@ -551,11 +704,12 @@ export default function Venue2D() {
           const isSelected = cam.id === selectedCameraId;
           const pos = effectiveCameraPos(cam);
           return (
-            <Group key={`cam-${cam.id}`} x={pos.x * ppm} y={pos.y * ppm} draggable={!drawingWall} onDragEnd={(e) => handleCamDragEnd(cam, e)} onClick={() => selectCamera(cam.id)} onTap={() => selectCamera(cam.id)}>
+            <Group key={`cam-${cam.id}`} x={pos.x * ppm} y={pos.y * ppm} draggable={!drawingWall && !cam.locked} onDragEnd={(e) => handleCamDragEnd(cam, e)} onClick={() => selectCamera(cam.id)} onTap={() => selectCamera(cam.id)} onContextMenu={(e) => openContextMenu('camera', cam.id, !!cam.locked, e)}>
               <Circle radius={isSelected ? 10 : 8} fill={cam.color} stroke={isSelected ? '#fff' : cam.color} strokeWidth={isSelected ? 3 : 1} shadowColor={cam.color} shadowBlur={isSelected ? 12 : 0} />
               <Line points={[0, 0, 14 * Math.cos((cam.pan * Math.PI) / 180), 14 * Math.sin((cam.pan * Math.PI) / 180)]} stroke={cam.color} strokeWidth={2} />
-              {/* Pan-rotation handle — drag to aim the camera (issue #36) */}
-              {isSelected && (
+              {/* Pan-rotation handle — drag to aim the camera (issue #36).
+                  Hidden while the camera is locked. */}
+              {isSelected && !cam.locked && (
                 <>
                   <Line
                     points={[0, 0, PAN_HANDLE_RADIUS * Math.cos((cam.pan * Math.PI) / 180), PAN_HANDLE_RADIUS * Math.sin((cam.pan * Math.PI) / 180)]}
@@ -574,7 +728,7 @@ export default function Venue2D() {
                   />
                 </>
               )}
-              <Text x={-16} y={12} text={cam.label} fontSize={11} fill="#fff" fontStyle="bold" align="center" width={32} />
+              <Text x={-16} y={12} text={cam.locked ? `${cam.label} 🔒` : cam.label} fontSize={11} fill="#fff" fontStyle="bold" align="center" width={32} />
             </Group>
           );
         })}
@@ -607,6 +761,39 @@ export default function Venue2D() {
         </Layer>
       )}
     </Stage>
+
+    {/* Right-click context menu (issue #38) */}
+    {menu && (
+      <div
+        onMouseDown={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute',
+          left: Math.min(menu.x, containerSize.w - 170),
+          top: Math.min(menu.y, containerSize.h - 110),
+          zIndex: 50,
+          minWidth: 150,
+          background: 'rgba(15,23,42,0.97)',
+          border: '1px solid #334155',
+          borderRadius: 8,
+          boxShadow: '0 10px 30px rgba(0,0,0,0.45)',
+          padding: 4,
+          fontSize: 12,
+          color: '#e2e8f0',
+          backdropFilter: 'blur(6px)',
+        }}
+      >
+        <button type="button" onClick={() => handleMenuAction('duplicate')} style={ctxItemStyle}>
+          <FiCopy size={13} /> Duplicate
+        </button>
+        <button type="button" onClick={() => handleMenuAction('lock')} style={ctxItemStyle}>
+          {menu.locked ? <FiUnlock size={13} /> : <FiLock size={13} />} {menu.locked ? 'Unlock position' : 'Lock position'}
+        </button>
+        <div style={{ height: 1, background: '#334155', margin: '4px 6px' }} />
+        <button type="button" onClick={() => handleMenuAction('delete')} style={{ ...ctxItemStyle, color: '#f87171' }}>
+          <FiTrash2 size={13} /> Delete {menu.kind}
+        </button>
+      </div>
+    )}
     </div>
   );
 }

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -29,6 +29,7 @@ interface AppState {
   addPerson: (x?: number, y?: number) => void;
   addStageObject: (objectType: StageObjectType, x?: number, y?: number) => void;
   removePerson: (id: string) => void;
+  duplicatePerson: (id: string) => void;
   updatePerson: (id: string, updates: Partial<ReferencePerson>) => void;
 
   // Custom lenses
@@ -261,6 +262,21 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   removePerson: (id) => set((s) => ({ persons: s.persons.filter((p) => p.id !== id), projectVersion: s.projectVersion + 1 })),
+
+  duplicatePerson: (id) =>
+    set((s) => {
+      const src = s.persons.find((p) => p.id === id);
+      if (!src) return s;
+      const dup: ReferencePerson = {
+        ...src,
+        id: personUid(),
+        label: `${src.label} copy`,
+        x: Math.min(s.venue.widthM, src.x + 0.5),
+        y: Math.min(s.venue.heightM, src.y + 0.5),
+        locked: false,
+      };
+      return { persons: [...s.persons, dup], projectVersion: s.projectVersion + 1 };
+    }),
 
   updatePerson: (id, updates) =>
     set((s) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -136,6 +136,8 @@ export interface ReferencePerson {
   objectType: StageObjectType;
   /** Optional custom accent colour (hex). Falls back to type default. */
   color?: string;
+  /** When true, the object can't be dragged in the 2D/3D plan. */
+  locked?: boolean;
 }
 
 // ── Background floor plan ──
@@ -216,6 +218,8 @@ export interface VenueCamera {
    * shot list, etc.). Shown in the sidebar and included in PNG exports when set.
    */
   notes?: string;
+  /** When true, the camera marker can't be dragged in the 2D plan. */
+  locked?: boolean;
 }
 
 // ── Stage / target zone ──
@@ -226,6 +230,8 @@ export interface Stage {
   width: number;
   height: number;
   label: string;
+  /** When true, the stage can't be dragged or resized in the 2D plan. */
+  locked?: boolean;
 }
 
 // ── Venue ──


### PR DESCRIPTION
**Batch 1 of the issue backlog** (quick UI wins). Each batch is a separate PR per your request.

## #44 — Sidebar reorder + tab rename
- Left tab **"Cameras" → "Settings"**.
- Section order is now **Venue Settings → Floor Plan → Walls → Objects & Persons → Cameras**. Stages is kept directly under Venue Settings (the issue's list omits it, but it's venue-structural — say the word if you'd rather move or merge it).

## #42 — Resize a stage by dragging edges/corners
- Click a stage in the 2D plan to select it → a Konva **Transformer** appears with corner + edge anchors.
- Dragging commits metric `width`/`height` (and `x`/`y`, since top/left anchors move the origin), clamped to a 0.5 m minimum. Click empty canvas to deselect.

## #38 — Right-click context menu
- Right-click a **camera**, **person/object**, or **stage** → menu with **Duplicate**, **Lock/Unlock position**, and **Delete** (red).
- Adds a `locked` flag to `VenueCamera` / `ReferencePerson` / `Stage`, respected by the 2D drag handlers and the pan-rotation handle; locked items show a 🔒 in their label. Adds a `duplicatePerson` store action.

## Verification
Headless (Electron + xvfb) — screenshots confirmed the "Settings" tab, the new section order, the stage resize anchors, and the context menu (Duplicate / Lock position / Delete stage), all with **0 console errors**.
- `npm run build` ✅ · `npm test` ✅ (47/47)

Note: lock is enforced in the 2D canvas; the 3D camera gizmo keeps its existing separate unlock flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqbqRGFKAp9iA61aig8Nwi)_