### PR TITLE
feat(preview): render walls (#46) + focus slider, manual zoom, optical presets (#47)

### DIFF
--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -42,6 +42,20 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   // Optical presets (issue #47), persisted globally.
   const [presets, setPresets] = useState<PreviewPreset[]>(() => loadJSON<PreviewPreset[]>(PREVIEW_PRESETS_KEY, []));
   const persistPresets = useCallback((next: PreviewPreset[]) => { setPresets(next); saveJSON(PREVIEW_PRESETS_KEY, next); }, []);
+  // Decoded wall pattern images, keyed by data URL (issue #45). A tick forces a
+  // repaint once an image finishes loading asynchronously.
+  const wallImageCache = useRef<Map<string, HTMLImageElement>>(new Map());
+  const [imageTick, setImageTick] = useState(0);
+  const getWallImage = useCallback((dataUrl: string): HTMLImageElement | null => {
+    const cache = wallImageCache.current;
+    const existing = cache.get(dataUrl);
+    if (existing) return existing.complete && existing.naturalWidth > 0 ? existing : null;
+    const img = new Image();
+    img.onload = () => setImageTick((t) => t + 1);
+    img.src = dataUrl;
+    cache.set(dataUrl, img);
+    return null;
+  }, []);
   // Cache projected person positions during draw() so the click handler can hit-test
   // without re-projecting everything itself.
   const projectedPersons = useRef<{ id: string; sx: number; sy: number; topSy: number; dist: number }[]>([]);
@@ -313,7 +327,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       })
       .sort((a, b) => b.dist - a.dist);
 
-    wallsByDist.forEach(({ wall }) => {
+    wallsByDist.forEach(({ wall, dist }) => {
       const camCorners = [
         worldToCamera(wall.x1, wall.y1, 0),
         worldToCamera(wall.x2, wall.y2, 0),
@@ -324,15 +338,84 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       if (clipped.length < 3) return;
       const projected = clipped.map((p) => cameraToScreen(p));
 
-      ctx.fillStyle = '#6b7280cc';
+      const baseColor = wall.color ?? '#6b7280';
+      const pattern = wall.pattern ?? 'solid';
+
+      // Depth-of-field blur for the wall, so a textured wall makes the focus
+      // falloff visible (issue #45). Same falloff model as persons.
+      const outOfFocus = Math.abs(dist - cam.focusDistance);
+      const wallBlur = Math.min(14, (outOfFocus * (cam.focalLength / 50)) / Math.max(1, cam.aperture) * 0.6);
+
+      ctx.save();
+      if (wallBlur > 0.5) ctx.filter = `blur(${wallBlur.toFixed(1)}px)`;
+
+      // Clip to the wall quad so the pattern only paints on the wall surface.
+      ctx.beginPath();
+      ctx.moveTo(projected[0].sx, projected[0].sy);
+      for (let i = 1; i < projected.length; i++) ctx.lineTo(projected[i].sx, projected[i].sy);
+      ctx.closePath();
+      ctx.save();
+      ctx.clip();
+
+      // Base fill.
+      ctx.fillStyle = baseColor + 'cc';
+      ctx.fill();
+
+      // Bounding box of the projected polygon (pattern is painted in screen space
+      // — not perspective-warped, but it gives the high-frequency detail needed to
+      // judge sharpness/blur).
+      const xs = projected.map((p) => p.sx);
+      const ys = projected.map((p) => p.sy);
+      const bx0 = Math.max(-50, Math.min(...xs));
+      const bx1 = Math.min(W + 50, Math.max(...xs));
+      const by0 = Math.max(-50, Math.min(...ys));
+      const by1 = Math.min(H + 50, Math.max(...ys));
+
+      if (pattern === 'grid') {
+        ctx.strokeStyle = 'rgba(255,255,255,0.35)';
+        ctx.lineWidth = 1;
+        const step = 16;
+        ctx.beginPath();
+        for (let x = bx0; x <= bx1; x += step) { ctx.moveTo(x, by0); ctx.lineTo(x, by1); }
+        for (let y = by0; y <= by1; y += step) { ctx.moveTo(bx0, y); ctx.lineTo(bx1, y); }
+        ctx.stroke();
+      } else if (pattern === 'flowers') {
+        ctx.fillStyle = 'rgba(255,255,255,0.55)';
+        const step = 26;
+        for (let y = by0; y <= by1; y += step) {
+          for (let x = bx0; x <= bx1; x += step) {
+            // simple 5-petal flower motif
+            for (let k = 0; k < 5; k++) {
+              const a = (k / 5) * Math.PI * 2;
+              ctx.beginPath();
+              ctx.arc(x + Math.cos(a) * 4, y + Math.sin(a) * 4, 2.6, 0, Math.PI * 2);
+              ctx.fill();
+            }
+            ctx.fillStyle = 'rgba(250,204,21,0.85)';
+            ctx.beginPath();
+            ctx.arc(x, y, 2.2, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = 'rgba(255,255,255,0.55)';
+          }
+        }
+      } else if (pattern === 'image' && wall.patternImage) {
+        const img = getWallImage(wall.patternImage);
+        if (img) {
+          const tile = ctx.createPattern(img, 'repeat');
+          if (tile) { ctx.fillStyle = tile; ctx.fillRect(bx0, by0, bx1 - bx0, by1 - by0); }
+        }
+      }
+      ctx.restore(); // remove clip
+
+      // Outline (still blurred if out of focus).
       ctx.strokeStyle = '#9ca3af';
       ctx.lineWidth = 1.5;
       ctx.beginPath();
       ctx.moveTo(projected[0].sx, projected[0].sy);
       for (let i = 1; i < projected.length; i++) ctx.lineTo(projected[i].sx, projected[i].sy);
       ctx.closePath();
-      ctx.fill();
       ctx.stroke();
+      ctx.restore(); // remove blur filter
     });
 
     // ── Draw persons / stage objects ──
@@ -865,7 +948,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
     ctx.textAlign = 'right';
     ctx.fillText(`P ${cam.pan.toFixed(1)}°  T ${cam.tilt.toFixed(1)}°`, W - vRulerW - 8, 16);
 
-  }, [cam, venue, persons, walls, cameras, showGrid, showSafeAreas, showThirds, showCrosshair]);
+  }, [cam, venue, persons, walls, cameras, showGrid, showSafeAreas, showThirds, showCrosshair, getWallImage, imageTick]);
 
   // Repaint synchronously after every render so pan/tilt drags update the canvas
   // on the very next browser frame. The earlier `useEffect` variant was being

--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -6,7 +6,13 @@ import { effectiveCameraPos } from '../../utils/camera';
 import { getExportRegistry } from '../../store/exportRegistry';
 import { useRef, useEffect, useLayoutEffect, useCallback, useState } from 'react';
 import type { StageObjectType } from '../../types';
-import { FiChevronLeft, FiChevronRight, FiUnlock, FiLock } from 'react-icons/fi';
+import { FiChevronLeft, FiChevronRight, FiUnlock, FiLock, FiPlus, FiX } from 'react-icons/fi';
+import { loadJSON, saveJSON } from '../../utils/storage';
+
+// Preview optical presets (issue #47) — snapshots of focal length / aperture /
+// focus distance the operator can recall. Persisted globally in localStorage.
+interface PreviewPreset { id: string; name: string; focalLength: number; aperture: number; focusDistance: number; }
+const PREVIEW_PRESETS_KEY = 'multicam-preview-presets';
 
 interface PreviewProps {
   undocked: boolean;
@@ -14,7 +20,7 @@ interface PreviewProps {
 }
 
 export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
-  const { cameras, selectedCameraId, venue, persons, selectNextCamera, selectPrevCamera } = useStore();
+  const { cameras, selectedCameraId, venue, persons, walls, selectNextCamera, selectPrevCamera } = useStore();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const cam = cameras.find((c) => c.id === selectedCameraId);
@@ -28,6 +34,14 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   const [showCrosshair, setShowCrosshair] = useState(true);
   const [showData, setShowData] = useState(true);
   const [focusPickMode, setFocusPickMode] = useState(false);
+  // Manual-zoom mode (issue #47): widen the focal-length slider past the lens's
+  // real range to preview hypothetical focal lengths. Both ends are editable.
+  const [manualZoom, setManualZoom] = useState(false);
+  const [manualMin, setManualMin] = useState(1);
+  const [manualMax, setManualMax] = useState(500);
+  // Optical presets (issue #47), persisted globally.
+  const [presets, setPresets] = useState<PreviewPreset[]>(() => loadJSON<PreviewPreset[]>(PREVIEW_PRESETS_KEY, []));
+  const persistPresets = useCallback((next: PreviewPreset[]) => { setPresets(next); saveJSON(PREVIEW_PRESETS_KEY, next); }, []);
   // Cache projected person positions during draw() so the click handler can hit-test
   // without re-projecting everything itself.
   const projectedPersons = useRef<{ id: string; sx: number; sy: number; topSy: number; dist: number }[]>([]);
@@ -283,6 +297,42 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
         ctx.textAlign = 'center';
         ctx.fillText(stage.label, center.sx, center.sy + fontSize / 3);
       }
+    });
+
+    // ── Draw walls from venue (issue #46) ──
+    // Each wall is a vertical quad standing on the floor: bottom edge from
+    // (x1,y1) to (x2,y2) at z=0, top edge at z=height. Built in camera space and
+    // near-plane clipped like the stages so corners behind the camera don't
+    // collapse the quad. Drawn back-to-front (farthest first) so nearer walls
+    // overpaint farther ones.
+    const wallsByDist = walls
+      .map((wall) => {
+        const midX = (wall.x1 + wall.x2) / 2;
+        const midY = (wall.y1 + wall.y2) / 2;
+        return { wall, dist: worldToScreen(midX, midY, 0).dist };
+      })
+      .sort((a, b) => b.dist - a.dist);
+
+    wallsByDist.forEach(({ wall }) => {
+      const camCorners = [
+        worldToCamera(wall.x1, wall.y1, 0),
+        worldToCamera(wall.x2, wall.y2, 0),
+        worldToCamera(wall.x2, wall.y2, wall.height),
+        worldToCamera(wall.x1, wall.y1, wall.height),
+      ];
+      const clipped = clipPolygonNear(camCorners);
+      if (clipped.length < 3) return;
+      const projected = clipped.map((p) => cameraToScreen(p));
+
+      ctx.fillStyle = '#6b7280cc';
+      ctx.strokeStyle = '#9ca3af';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(projected[0].sx, projected[0].sy);
+      for (let i = 1; i < projected.length; i++) ctx.lineTo(projected[i].sx, projected[i].sy);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
     });
 
     // ── Draw persons / stage objects ──
@@ -815,7 +865,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
     ctx.textAlign = 'right';
     ctx.fillText(`P ${cam.pan.toFixed(1)}°  T ${cam.tilt.toFixed(1)}°`, W - vRulerW - 8, 16);
 
-  }, [cam, venue, persons, cameras, showGrid, showSafeAreas, showThirds, showCrosshair]);
+  }, [cam, venue, persons, walls, cameras, showGrid, showSafeAreas, showThirds, showCrosshair]);
 
   // Repaint synchronously after every render so pan/tilt drags update the canvas
   // on the very next browser frame. The earlier `useEffect` variant was being
@@ -966,6 +1016,26 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
 
   const camIdx = cameras.findIndex((c) => c.id === cam.id);
 
+  // Upper bound for the focus-distance slider — roughly the venue diagonal.
+  const focusMax = Math.max(20, Math.ceil(Math.hypot(venue.widthM, venue.heightM)));
+
+  const addPreset = () => {
+    const name = window.prompt('Preset name:', `${cam.focalLength.toFixed(0)}mm f/${cam.aperture.toFixed(1)}`);
+    if (!name) return;
+    persistPresets([...presets, { id: Date.now().toString(36), name: name.trim(), focalLength: cam.focalLength, aperture: cam.aperture, focusDistance: cam.focusDistance }]);
+  };
+  const applyPreset = (p: PreviewPreset) => {
+    useStore.getState().updateCamera(cam.id, { focalLength: p.focalLength, aperture: p.aperture, focusDistance: p.focusDistance, lockedPersonId: undefined });
+    // A preset can hold a focal length outside the lens's native range, so make
+    // sure the slider can represent it.
+    if (lensDef && (p.focalLength < lensDef.focalLengthMin || p.focalLength > lensDef.focalLengthMax)) {
+      setManualZoom(true);
+      setManualMin((m) => Math.min(m, Math.floor(p.focalLength)));
+      setManualMax((m) => Math.max(m, Math.ceil(p.focalLength)));
+    }
+  };
+  const deletePreset = (id: string) => persistPresets(presets.filter((p) => p.id !== id));
+
   return (
     <div className="relative w-full h-full flex gap-2 overflow-hidden">
       {/* Left: Canvas + controls */}
@@ -1063,19 +1133,91 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
           </span>
         </div>
 
-        {/* Zoom slider */}
-        <div className="flex items-center gap-3 px-2">
-          <span className="text-xs text-gray-400 w-16 font-mono">{cam.focalLength.toFixed(0)}mm</span>
-          <input
-            type="range"
-            min={lensDef?.focalLengthMin ?? 4}
-            max={lensDef?.focalLengthMax ?? 300}
-            step={0.1}
-            value={cam.focalLength}
-            onChange={(e) => useStore.getState().updateCamera(cam.id, { focalLength: parseFloat(e.target.value) })}
-            className="flex-1 accent-bc-accent"
-          />
-          <span className="text-xs text-gray-400 w-16 text-right font-mono">{lensDef?.focalLengthMax ?? '?'}mm</span>
+        {/* Zoom (focal length) slider — Manual mode (#47) widens the range past
+            the lens limits and makes both ends editable. */}
+        <div className="px-2">
+          <div className="flex items-center justify-between mb-0.5">
+            <span className="text-[10px] text-gray-500">Zoom · <span className="font-mono text-gray-300">{cam.focalLength.toFixed(0)}mm</span></span>
+            <button
+              onClick={() => setManualZoom((on) => {
+                const next = !on;
+                if (!next && lensDef) {
+                  const clamped = Math.min(lensDef.focalLengthMax, Math.max(lensDef.focalLengthMin, cam.focalLength));
+                  if (clamped !== cam.focalLength) useStore.getState().updateCamera(cam.id, { focalLength: clamped });
+                }
+                return next;
+              })}
+              title="Temporarily scrub focal length beyond the lens's real range"
+              className={`px-2 py-0.5 rounded text-[10px] font-medium border transition-colors ${manualZoom ? 'border-bc-yellow text-bc-yellow bg-bc-yellow/10' : 'border-bc-border text-gray-500 hover:text-gray-300'}`}
+            >
+              Manual{manualZoom ? ' · ON' : ''}
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            {manualZoom ? (
+              <input
+                type="number" min={1} max={manualMax - 1} value={manualMin}
+                onChange={(e) => setManualMin(Math.max(1, Math.min(manualMax - 1, parseFloat(e.target.value) || 1)))}
+                className="w-14 bg-bc-dark border border-bc-border rounded px-1 py-0.5 text-[10px] text-gray-300 font-mono"
+                title="Manual minimum focal length (mm)"
+              />
+            ) : (
+              <span className="text-[10px] text-gray-500 w-14 font-mono">{lensDef?.focalLengthMin ?? 4}mm</span>
+            )}
+            <input
+              type="range"
+              min={manualZoom ? manualMin : (lensDef?.focalLengthMin ?? 4)}
+              max={manualZoom ? manualMax : (lensDef?.focalLengthMax ?? 300)}
+              step={0.1}
+              value={cam.focalLength}
+              onChange={(e) => useStore.getState().updateCamera(cam.id, { focalLength: parseFloat(e.target.value) })}
+              className="flex-1 accent-bc-accent"
+            />
+            {manualZoom ? (
+              <input
+                type="number" min={manualMin + 1} max={2000} value={manualMax}
+                onChange={(e) => setManualMax(Math.max(manualMin + 1, Math.min(2000, parseFloat(e.target.value) || 500)))}
+                className="w-14 bg-bc-dark border border-bc-border rounded px-1 py-0.5 text-[10px] text-gray-300 font-mono text-right"
+                title="Manual maximum focal length (mm)"
+              />
+            ) : (
+              <span className="text-[10px] text-gray-500 w-14 text-right font-mono">{lensDef?.focalLengthMax ?? '?'}mm</span>
+            )}
+          </div>
+        </div>
+
+        {/* Focus distance slider (#47) */}
+        <div className="px-2">
+          <div className="flex items-center justify-between mb-0.5">
+            <span className="text-[10px] text-gray-500">Focus · <span className="font-mono text-gray-300">{cam.focusDistance.toFixed(1)}m</span>{cam.lockedPersonId ? ' · locked' : ''}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-gray-500 w-14 font-mono">0.5m</span>
+            <input
+              type="range"
+              min={0.5}
+              max={focusMax}
+              step={0.1}
+              value={Math.min(cam.focusDistance, focusMax)}
+              onChange={(e) => useStore.getState().updateCamera(cam.id, { focusDistance: Math.max(0.1, parseFloat(e.target.value)), lockedPersonId: undefined })}
+              className="flex-1 accent-bc-accent"
+            />
+            <span className="text-[10px] text-gray-500 w-14 text-right font-mono">{focusMax}m</span>
+          </div>
+        </div>
+
+        {/* Optical presets (#47) */}
+        <div className="px-2 flex items-center gap-2 flex-wrap">
+          <span className="text-[10px] text-gray-500">Presets</span>
+          {presets.map((p) => (
+            <span key={p.id} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] border border-bc-border text-gray-300 hover:border-bc-accent">
+              <button onClick={() => applyPreset(p)} title={`${p.focalLength.toFixed(0)}mm · f/${p.aperture.toFixed(1)} · ${p.focusDistance.toFixed(1)}m`}>{p.name}</button>
+              <button onClick={() => deletePreset(p.id)} className="text-gray-600 hover:text-bc-red" title="Delete preset"><FiX size={10} /></button>
+            </span>
+          ))}
+          <button onClick={addPreset} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] border border-bc-border text-gray-500 hover:text-bc-accent hover:border-bc-accent" title="Save current focal length / aperture / focus as a preset">
+            <FiPlus size={10} /> Add
+          </button>
         </div>
       </div>
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -4,7 +4,7 @@ import { LENSES, getLensById, getCompatibleLenses, pickInitialMountAndLens } fro
 import { computeFov, computeDof } from '../../utils/fov';
 import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiEdit2, FiRotateCcw } from 'react-icons/fi';
 import { useState, useRef, useCallback, useEffect } from 'react';
-import type { BackgroundPlan, StageObjectType, Camera, CameraMountType } from '../../types';
+import type { BackgroundPlan, StageObjectType, Camera, CameraMountType, WallPattern } from '../../types';
 import { MOUNT_TYPE_LABELS, MOUNT_HEIGHT_RANGE } from '../../types';
 import { CustomCameraForm } from './CustomCameraForm';
 import { CalculationBreakdown } from './CalculationBreakdown';
@@ -1174,14 +1174,61 @@ export default function Sidebar() {
               </div>
             )}
             {walls.map((w) => (
-              <div key={w.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
-                <input
-                  className="bg-transparent text-white text-xs w-16 outline-none"
-                  value={w.label}
-                  onChange={(e) => updateWall(w.id, { label: e.target.value })}
-                />
-                <span className="text-gray-500 text-[10px]">{w.height}m h</span>
-                <button onClick={() => removeWall(w.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
+              <div key={w.id} className="bg-bc-dark rounded p-1.5 border border-bc-border space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <input
+                    className="bg-transparent text-white text-xs w-16 outline-none"
+                    value={w.label}
+                    onChange={(e) => updateWall(w.id, { label: e.target.value })}
+                  />
+                  <span className="text-gray-500 text-[10px]">{w.height}m h</span>
+                  <button onClick={() => removeWall(w.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
+                </div>
+                {/* Surface pattern for blur-checking in the preview (issue #45) */}
+                <div className="flex items-center gap-1">
+                  <input
+                    type="color"
+                    className="w-5 h-5 rounded border border-bc-border cursor-pointer bg-transparent shrink-0"
+                    value={w.color ?? '#6b7280'}
+                    onChange={(e) => updateWall(w.id, { color: e.target.value })}
+                    title="Wall colour"
+                  />
+                  <select
+                    className="flex-1 bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[10px]"
+                    value={w.pattern ?? 'solid'}
+                    onChange={(e) => updateWall(w.id, { pattern: e.target.value as WallPattern })}
+                  >
+                    <option value="solid">Solid</option>
+                    <option value="grid">Grid</option>
+                    <option value="flowers">Flowers</option>
+                    <option value="image">Image…</option>
+                  </select>
+                  {w.pattern === 'image' && (
+                    <label className="px-1.5 py-0.5 rounded bg-bc-accent/20 text-bc-accent text-[10px] cursor-pointer hover:bg-bc-accent/30" title="Upload a tiled image">
+                      <FiUpload size={10} className="inline" />
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (!file) return;
+                          const reader = new FileReader();
+                          reader.onload = () => updateWall(w.id, { patternImage: String(reader.result), pattern: 'image' });
+                          reader.readAsDataURL(file);
+                          e.target.value = '';
+                        }}
+                      />
+                    </label>
+                  )}
+                  <button
+                    onClick={() => walls.forEach((other) => other.id !== w.id && updateWall(other.id, { color: w.color, pattern: w.pattern, patternImage: w.patternImage }))}
+                    className="px-1.5 py-0.5 rounded border border-bc-border text-gray-400 hover:text-bc-accent hover:border-bc-accent text-[10px] shrink-0"
+                    title="Apply this wall's colour & pattern to all walls"
+                  >
+                    All
+                  </button>
+                </div>
               </div>
             ))}
             <button

--- a/src/components/Venue3D/Venue3D.tsx
+++ b/src/components/Venue3D/Venue3D.tsx
@@ -983,7 +983,7 @@ export default function Venue3D() {
           return (
             <mesh key={w.id} position={[cx, w.height / 2, cy]} rotation={[0, -angle, 0]}>
               <boxGeometry args={[len, w.height, 0.15]} />
-              <meshStandardMaterial color="#6b7280" opacity={0.6} transparent />
+              <meshStandardMaterial color={w.color ?? '#6b7280'} opacity={0.6} transparent />
             </mesh>
           );
         })}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,12 +117,22 @@ export const MOUNT_HEIGHT_RANGE: Record<CameraMountType, { min: number; max: num
 
 
 // ── Venue wall ──
+// `pattern` controls the wall surface texture in the camera preview so an
+// operator can judge focus/blur against a known motif (issue #45).
+export type WallPattern = 'solid' | 'grid' | 'flowers' | 'image';
+
 export interface Wall {
   id: string;
   x1: number; y1: number; // start point in metres
   x2: number; y2: number; // end point in metres
   height: number; // metres
   label: string;
+  /** Base surface colour (hex). Falls back to a neutral grey when unset. */
+  color?: string;
+  /** Surface pattern for blur-checking in the preview. Defaults to 'solid'. */
+  pattern?: WallPattern;
+  /** Data URL of a custom image, tiled across the wall when pattern === 'image'. */
+  patternImage?: string;
 }
 
 // ── Reference person / object in venue ──


### PR DESCRIPTION
**Batch 2 of the issue backlog** — Preview fixes.

## #46 — Walls not rendered in the Preview window
Walls are now drawn in the camera preview. Each wall is projected as a vertical quad (floor edge → its height), near-plane clipped exactly like the stages, and painted back-to-front so nearer walls overpaint farther ones.

## #47 — Preview tab improvements
- **Focus distance slider** beneath the zoom slider (0.5 m … venue diagonal). Dragging it clears any active focus-lock.
- **Manual zoom mode**: a temporary toggle that widens the focal-length slider past the lens's real range so you can preview hypothetical focal lengths. Both ends become editable number inputs (default **1–500 mm**). Turning it off snaps the focal length back into the lens's native range.
- **Optical presets**: save the current focal length / aperture / focus distance as a named preset (persisted in `localStorage`), recall on click, delete with ×. Applying a preset whose focal length is outside the lens range auto-enables manual mode so the slider can represent it.

## Verification
Headless (Electron + xvfb):
- Walls project correctly in perspective — confirmed with a temporary bright fill (filled the frame for a wall directly in front) and an angled pan (wall recedes to a vanishing point alongside the stage).
- Focus slider, manual min/max inputs, and the presets row all render; manual toggle shows the two editable inputs (1 / 500).
- **0 console errors.** `npm run build` ✅ · `npm test` ✅ (47/47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqbqRGFKAp9iA61aig8Nwi)_