### PR TITLE
feat(walls): per-wall colour + patterns for blur-checking (#45)

### DIFF
--- a/src/components/Preview/CameraPreview.tsx
+++ b/src/components/Preview/CameraPreview.tsx
@@ -42,6 +42,20 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
   // Optical presets (issue #47), persisted globally.
   const [presets, setPresets] = useState<PreviewPreset[]>(() => loadJSON<PreviewPreset[]>(PREVIEW_PRESETS_KEY, []));
   const persistPresets = useCallback((next: PreviewPreset[]) => { setPresets(next); saveJSON(PREVIEW_PRESETS_KEY, next); }, []);
+  // Decoded wall pattern images, keyed by data URL (issue #45). A tick forces a
+  // repaint once an image finishes loading asynchronously.
+  const wallImageCache = useRef<Map<string, HTMLImageElement>>(new Map());
+  const [imageTick, setImageTick] = useState(0);
+  const getWallImage = useCallback((dataUrl: string): HTMLImageElement | null => {
+    const cache = wallImageCache.current;
+    const existing = cache.get(dataUrl);
+    if (existing) return existing.complete && existing.naturalWidth > 0 ? existing : null;
+    const img = new Image();
+    img.onload = () => setImageTick((t) => t + 1);
+    img.src = dataUrl;
+    cache.set(dataUrl, img);
+    return null;
+  }, []);
   // Cache projected person positions during draw() so the click handler can hit-test
   // without re-projecting everything itself.
   const projectedPersons = useRef<{ id: string; sx: number; sy: number; topSy: number; dist: number }[]>([]);
@@ -313,7 +327,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       })
       .sort((a, b) => b.dist - a.dist);
 
-    wallsByDist.forEach(({ wall }) => {
+    wallsByDist.forEach(({ wall, dist }) => {
       const camCorners = [
         worldToCamera(wall.x1, wall.y1, 0),
         worldToCamera(wall.x2, wall.y2, 0),
@@ -324,15 +338,84 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
       if (clipped.length < 3) return;
       const projected = clipped.map((p) => cameraToScreen(p));
 
-      ctx.fillStyle = '#6b7280cc';
+      const baseColor = wall.color ?? '#6b7280';
+      const pattern = wall.pattern ?? 'solid';
+
+      // Depth-of-field blur for the wall, so a textured wall makes the focus
+      // falloff visible (issue #45). Same falloff model as persons.
+      const outOfFocus = Math.abs(dist - cam.focusDistance);
+      const wallBlur = Math.min(14, (outOfFocus * (cam.focalLength / 50)) / Math.max(1, cam.aperture) * 0.6);
+
+      ctx.save();
+      if (wallBlur > 0.5) ctx.filter = `blur(${wallBlur.toFixed(1)}px)`;
+
+      // Clip to the wall quad so the pattern only paints on the wall surface.
+      ctx.beginPath();
+      ctx.moveTo(projected[0].sx, projected[0].sy);
+      for (let i = 1; i < projected.length; i++) ctx.lineTo(projected[i].sx, projected[i].sy);
+      ctx.closePath();
+      ctx.save();
+      ctx.clip();
+
+      // Base fill.
+      ctx.fillStyle = baseColor + 'cc';
+      ctx.fill();
+
+      // Bounding box of the projected polygon (pattern is painted in screen space
+      // — not perspective-warped, but it gives the high-frequency detail needed to
+      // judge sharpness/blur).
+      const xs = projected.map((p) => p.sx);
+      const ys = projected.map((p) => p.sy);
+      const bx0 = Math.max(-50, Math.min(...xs));
+      const bx1 = Math.min(W + 50, Math.max(...xs));
+      const by0 = Math.max(-50, Math.min(...ys));
+      const by1 = Math.min(H + 50, Math.max(...ys));
+
+      if (pattern === 'grid') {
+        ctx.strokeStyle = 'rgba(255,255,255,0.35)';
+        ctx.lineWidth = 1;
+        const step = 16;
+        ctx.beginPath();
+        for (let x = bx0; x <= bx1; x += step) { ctx.moveTo(x, by0); ctx.lineTo(x, by1); }
+        for (let y = by0; y <= by1; y += step) { ctx.moveTo(bx0, y); ctx.lineTo(bx1, y); }
+        ctx.stroke();
+      } else if (pattern === 'flowers') {
+        ctx.fillStyle = 'rgba(255,255,255,0.55)';
+        const step = 26;
+        for (let y = by0; y <= by1; y += step) {
+          for (let x = bx0; x <= bx1; x += step) {
+            // simple 5-petal flower motif
+            for (let k = 0; k < 5; k++) {
+              const a = (k / 5) * Math.PI * 2;
+              ctx.beginPath();
+              ctx.arc(x + Math.cos(a) * 4, y + Math.sin(a) * 4, 2.6, 0, Math.PI * 2);
+              ctx.fill();
+            }
+            ctx.fillStyle = 'rgba(250,204,21,0.85)';
+            ctx.beginPath();
+            ctx.arc(x, y, 2.2, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = 'rgba(255,255,255,0.55)';
+          }
+        }
+      } else if (pattern === 'image' && wall.patternImage) {
+        const img = getWallImage(wall.patternImage);
+        if (img) {
+          const tile = ctx.createPattern(img, 'repeat');
+          if (tile) { ctx.fillStyle = tile; ctx.fillRect(bx0, by0, bx1 - bx0, by1 - by0); }
+        }
+      }
+      ctx.restore(); // remove clip
+
+      // Outline (still blurred if out of focus).
       ctx.strokeStyle = '#9ca3af';
       ctx.lineWidth = 1.5;
       ctx.beginPath();
       ctx.moveTo(projected[0].sx, projected[0].sy);
       for (let i = 1; i < projected.length; i++) ctx.lineTo(projected[i].sx, projected[i].sy);
       ctx.closePath();
-      ctx.fill();
       ctx.stroke();
+      ctx.restore(); // remove blur filter
     });
 
     // ── Draw persons / stage objects ──
@@ -865,7 +948,7 @@ export default function CameraPreview({ undocked, onUndock }: PreviewProps) {
     ctx.textAlign = 'right';
     ctx.fillText(`P ${cam.pan.toFixed(1)}°  T ${cam.tilt.toFixed(1)}°`, W - vRulerW - 8, 16);
 
-  }, [cam, venue, persons, walls, cameras, showGrid, showSafeAreas, showThirds, showCrosshair]);
+  }, [cam, venue, persons, walls, cameras, showGrid, showSafeAreas, showThirds, showCrosshair, getWallImage, imageTick]);
 
   // Repaint synchronously after every render so pan/tilt drags update the canvas
   // on the very next browser frame. The earlier `useEffect` variant was being

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -4,7 +4,7 @@ import { LENSES, getLensById, getCompatibleLenses, pickInitialMountAndLens } fro
 import { computeFov, computeDof } from '../../utils/fov';
 import { FiPlus, FiTrash2, FiCopy, FiChevronDown, FiChevronUp, FiEye, FiEyeOff, FiUpload, FiUser, FiMap, FiMaximize2, FiLock, FiUnlock, FiStar, FiEdit2, FiRotateCcw } from 'react-icons/fi';
 import { useState, useRef, useCallback, useEffect } from 'react';
-import type { BackgroundPlan, StageObjectType, Camera, CameraMountType } from '../../types';
+import type { BackgroundPlan, StageObjectType, Camera, CameraMountType, WallPattern } from '../../types';
 import { MOUNT_TYPE_LABELS, MOUNT_HEIGHT_RANGE } from '../../types';
 import { CustomCameraForm } from './CustomCameraForm';
 import { CalculationBreakdown } from './CalculationBreakdown';
@@ -1174,14 +1174,61 @@ export default function Sidebar() {
               </div>
             )}
             {walls.map((w) => (
-              <div key={w.id} className="flex items-center gap-2 bg-bc-dark rounded p-1.5 border border-bc-border">
-                <input
-                  className="bg-transparent text-white text-xs w-16 outline-none"
-                  value={w.label}
-                  onChange={(e) => updateWall(w.id, { label: e.target.value })}
-                />
-                <span className="text-gray-500 text-[10px]">{w.height}m h</span>
-                <button onClick={() => removeWall(w.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
+              <div key={w.id} className="bg-bc-dark rounded p-1.5 border border-bc-border space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <input
+                    className="bg-transparent text-white text-xs w-16 outline-none"
+                    value={w.label}
+                    onChange={(e) => updateWall(w.id, { label: e.target.value })}
+                  />
+                  <span className="text-gray-500 text-[10px]">{w.height}m h</span>
+                  <button onClick={() => removeWall(w.id)} className="ml-auto p-0.5 hover:text-bc-red"><FiTrash2 size={11} /></button>
+                </div>
+                {/* Surface pattern for blur-checking in the preview (issue #45) */}
+                <div className="flex items-center gap-1">
+                  <input
+                    type="color"
+                    className="w-5 h-5 rounded border border-bc-border cursor-pointer bg-transparent shrink-0"
+                    value={w.color ?? '#6b7280'}
+                    onChange={(e) => updateWall(w.id, { color: e.target.value })}
+                    title="Wall colour"
+                  />
+                  <select
+                    className="flex-1 bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[10px]"
+                    value={w.pattern ?? 'solid'}
+                    onChange={(e) => updateWall(w.id, { pattern: e.target.value as WallPattern })}
+                  >
+                    <option value="solid">Solid</option>
+                    <option value="grid">Grid</option>
+                    <option value="flowers">Flowers</option>
+                    <option value="image">Image…</option>
+                  </select>
+                  {w.pattern === 'image' && (
+                    <label className="px-1.5 py-0.5 rounded bg-bc-accent/20 text-bc-accent text-[10px] cursor-pointer hover:bg-bc-accent/30" title="Upload a tiled image">
+                      <FiUpload size={10} className="inline" />
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (!file) return;
+                          const reader = new FileReader();
+                          reader.onload = () => updateWall(w.id, { patternImage: String(reader.result), pattern: 'image' });
+                          reader.readAsDataURL(file);
+                          e.target.value = '';
+                        }}
+                      />
+                    </label>
+                  )}
+                  <button
+                    onClick={() => walls.forEach((other) => other.id !== w.id && updateWall(other.id, { color: w.color, pattern: w.pattern, patternImage: w.patternImage }))}
+                    className="px-1.5 py-0.5 rounded border border-bc-border text-gray-400 hover:text-bc-accent hover:border-bc-accent text-[10px] shrink-0"
+                    title="Apply this wall's colour & pattern to all walls"
+                  >
+                    All
+                  </button>
+                </div>
               </div>
             ))}
             <button

--- a/src/components/Venue3D/Venue3D.tsx
+++ b/src/components/Venue3D/Venue3D.tsx
@@ -983,7 +983,7 @@ export default function Venue3D() {
           return (
             <mesh key={w.id} position={[cx, w.height / 2, cy]} rotation={[0, -angle, 0]}>
               <boxGeometry args={[len, w.height, 0.15]} />
-              <meshStandardMaterial color="#6b7280" opacity={0.6} transparent />
+              <meshStandardMaterial color={w.color ?? '#6b7280'} opacity={0.6} transparent />
             </mesh>
           );
         })}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,12 +117,22 @@ export const MOUNT_HEIGHT_RANGE: Record<CameraMountType, { min: number; max: num
 
 
 // ── Venue wall ──
+// `pattern` controls the wall surface texture in the camera preview so an
+// operator can judge focus/blur against a known motif (issue #45).
+export type WallPattern = 'solid' | 'grid' | 'flowers' | 'image';
+
 export interface Wall {
   id: string;
   x1: number; y1: number; // start point in metres
   x2: number; y2: number; // end point in metres
   height: number; // metres
   label: string;
+  /** Base surface colour (hex). Falls back to a neutral grey when unset. */
+  color?: string;
+  /** Surface pattern for blur-checking in the preview. Defaults to 'solid'. */
+  pattern?: WallPattern;
+  /** Data URL of a custom image, tiled across the wall when pattern === 'image'. */
+  patternImage?: string;
 }
 
 // ── Reference person / object in venue ──


### PR DESCRIPTION
**Batch 3 of the issue backlog** — wall patterns (#45).

> **Stacked on #49 (Batch 2).** This PR targets the `claude/batch2-preview-fixes` branch because #45 (wall *patterns* in the preview) builds directly on #46 (walls *rendered* in the preview). After #49 merges to `master`, I'll retarget this PR to `master` and its diff will collapse to just the pattern work.

## #45 — Walls mit Muster (patterns for blur-checking)
- **Data model**: `Wall` gains `color`, `pattern` (`solid` | `grid` | `flowers` | `image`), and `patternImage` (tiled data URL).
- **Preview**: each wall is painted with its colour + pattern, clipped to the wall quad, and gets a **depth-of-field blur** based on the wall's distance vs the focus distance — so a textured wall makes the focus falloff visible (the whole point of the issue). Pattern tiling is screen-space (not perspective-warped), which is enough to judge sharpness.
- **Sidebar** (Walls section): per-wall colour picker, pattern dropdown, image upload (for the `image` pattern), and an **"All"** button that copies the current wall's colour + pattern to every wall — covering the issue's "overwrite all walls" / "save current wall" options.
- **3D view** honours the wall colour too.

## Verification
Headless (Electron + xvfb): the flowers pattern renders across the wall in the preview, and the sidebar colour/pattern/All controls work — **0 console errors**. `npm run build` ✅ · `npm test` ✅ (47/47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqbqRGFKAp9iA61aig8Nwi)_