### PR TITLE
feat(ai): multi-provider AI floor-plan analysis (#39, #40)

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -43,7 +43,7 @@ function createMainWindow() {
         ...details.responseHeaders,
         'Content-Security-Policy': [
           "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
-          "img-src 'self' data: blob:; connect-src 'self' https://generativelanguage.googleapis.com data:; " +
+          "img-src 'self' data: blob:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://api.anthropic.com https://api.mistral.ai https://api.x.ai data:; " +
           "font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
         ],
       },

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://generativelanguage.googleapis.com data:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'" />
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://api.anthropic.com https://api.mistral.ai https://api.x.ai data:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MultiCam Planner – Broadcast Camera &amp; Lens Planning</title>

--- a/src/components/Sidebar/AiPlanAnalysis.tsx
+++ b/src/components/Sidebar/AiPlanAnalysis.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useState } from 'react';
+import { FiCpu, FiKey, FiLoader } from 'react-icons/fi';
+import { useStore } from '../../store/useStore';
+import { AI_PROVIDERS, AI_PROVIDER_ORDER, splitDataUrl, parseJsonResponse } from '../../utils/aiProviders';
+import type { AiProviderId } from '../../utils/aiProviders';
+import { buildPlanPrompt, wallsFromResult, stagesFromResult } from '../../utils/planAnalysis';
+import type { AnalysisResult, PlanTasks } from '../../utils/planAnalysis';
+
+const PROVIDER_STORAGE = 'multicam-ai-provider';
+const modelStorageKey = (id: AiProviderId) => `multicam-ai-model-${id}`;
+
+// AI floor-plan analysis (issues #39 / #40): pick a provider, paste a key, and
+// have the model extract walls / stages / scale from the uploaded plan image.
+export default function AiPlanAnalysis() {
+  const { backgroundPlan, setBackgroundPlan, addWall, addStage } = useStore();
+
+  const initialProviderId: AiProviderId = (localStorage.getItem(PROVIDER_STORAGE) as AiProviderId) in AI_PROVIDERS
+    ? (localStorage.getItem(PROVIDER_STORAGE) as AiProviderId)
+    : 'gemini';
+  const [providerId, setProviderId] = useState<AiProviderId>(initialProviderId);
+  const provider = AI_PROVIDERS[providerId];
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem(AI_PROVIDERS[initialProviderId].keyStorageKey) ?? '');
+  const [model, setModel] = useState(
+    () => localStorage.getItem(modelStorageKey(initialProviderId)) ?? AI_PROVIDERS[initialProviderId].defaultModel,
+  );
+  const [tasks, setTasks] = useState<PlanTasks>({ walls: true, stages: true, scale: true });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<string | null>(null);
+
+  // Load the stored key + model whenever the provider changes.
+  const selectProvider = useCallback((id: AiProviderId) => {
+    setProviderId(id);
+    localStorage.setItem(PROVIDER_STORAGE, id);
+    setApiKey(localStorage.getItem(AI_PROVIDERS[id].keyStorageKey) ?? '');
+    setModel(localStorage.getItem(modelStorageKey(id)) ?? AI_PROVIDERS[id].defaultModel);
+    setError(null);
+    setSummary(null);
+  }, []);
+
+  const persistKey = useCallback((value: string) => {
+    setApiKey(value);
+    if (value.trim()) localStorage.setItem(provider.keyStorageKey, value.trim());
+    else localStorage.removeItem(provider.keyStorageKey);
+  }, [provider.keyStorageKey]);
+
+  const persistModel = useCallback((value: string) => {
+    setModel(value);
+    localStorage.setItem(modelStorageKey(providerId), value);
+  }, [providerId]);
+
+  const analyze = useCallback(async () => {
+    if (!backgroundPlan) { setError('Upload a floor plan image/PDF first.'); return; }
+    if (!apiKey.trim()) { setError(`Enter your ${provider.label} API key.`); return; }
+    if (!tasks.walls && !tasks.stages && !tasks.scale) { setError('Select at least one thing to extract.'); return; }
+
+    setBusy(true);
+    setError(null);
+    setSummary(null);
+    try {
+      const image = splitDataUrl(backgroundPlan.dataUrl);
+      const prompt = buildPlanPrompt(tasks);
+      const text = await provider.callVision(apiKey.trim(), model.trim() || provider.defaultModel, prompt, image);
+      const result = parseJsonResponse<AnalysisResult>(text);
+
+      // Apply the scale first so wall/stage geometry uses the corrected scale.
+      let plan = backgroundPlan;
+      let scaleNote = '';
+      if (tasks.scale && result.scale && typeof result.scale.metersPerPixel === 'number' && result.scale.metersPerPixel > 0) {
+        plan = { ...backgroundPlan, scaleX: result.scale.metersPerPixel, scaleY: result.scale.metersPerPixel };
+        setBackgroundPlan(plan);
+        scaleNote = `scale ${(result.scale.metersPerPixel * 1000).toFixed(1)} mm/px`;
+      }
+
+      const parts: string[] = [];
+      if (tasks.walls) {
+        const walls = wallsFromResult(result, plan);
+        walls.forEach((w) => addWall(w));
+        parts.push(`${walls.length} wall${walls.length === 1 ? '' : 's'}`);
+      }
+      if (tasks.stages) {
+        const stages = stagesFromResult(result, plan);
+        stages.forEach((s) => addStage(s));
+        parts.push(`${stages.length} stage${stages.length === 1 ? '' : 's'}`);
+      }
+      if (scaleNote) parts.push(scaleNote);
+
+      setSummary(parts.length ? `Added ${parts.join(', ')}.` : 'Nothing was detected in the plan.');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, [apiKey, backgroundPlan, model, provider, setBackgroundPlan, addWall, addStage, tasks]);
+
+  return (
+    <div className="p-2 rounded bg-bc-dark border border-bc-border space-y-1.5">
+      <div className="flex items-center gap-1 text-gray-300 font-medium">
+        <FiCpu size={11} /> AI Plan Analysis
+      </div>
+      <p className="text-gray-500 text-[10px] leading-tight">
+        Let an AI read the uploaded plan and draw walls / stages and read the scale.
+      </p>
+
+      {/* Provider + model */}
+      <select
+        className="w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[11px]"
+        value={providerId}
+        onChange={(e) => selectProvider(e.target.value as AiProviderId)}
+      >
+        {AI_PROVIDER_ORDER.map((id) => (
+          <option key={id} value={id}>
+            {AI_PROVIDERS[id].label}{AI_PROVIDERS[id].free ? ' — free key' : ''}
+          </option>
+        ))}
+      </select>
+
+      <div className="flex items-center gap-1">
+        <FiKey size={11} className="text-gray-500 shrink-0" />
+        <input
+          type="password"
+          placeholder={`${provider.label} API key`}
+          className="flex-1 bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[11px]"
+          value={apiKey}
+          onChange={(e) => persistKey(e.target.value)}
+        />
+      </div>
+      <p className="text-gray-600 text-[9px]">{provider.keyHint}</p>
+
+      <input
+        type="text"
+        placeholder="model"
+        className="w-full bg-bc-panel border border-bc-border rounded px-1 py-0.5 text-white text-[10px]"
+        value={model}
+        onChange={(e) => persistModel(e.target.value)}
+        title="Model id — defaults to a vision-capable model for the provider"
+      />
+
+      {/* What to extract */}
+      <div className="flex flex-wrap gap-2 text-[10px] text-gray-300">
+        {(['walls', 'stages', 'scale'] as const).map((k) => (
+          <label key={k} className="flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              className="accent-bc-accent"
+              checked={tasks[k]}
+              onChange={(e) => setTasks((t) => ({ ...t, [k]: e.target.checked }))}
+            />
+            {k.charAt(0).toUpperCase() + k.slice(1)}
+          </label>
+        ))}
+      </div>
+
+      <button
+        onClick={analyze}
+        disabled={busy || !backgroundPlan}
+        className="flex items-center justify-center gap-1 px-2 py-1 rounded bg-bc-accent/20 text-bc-accent text-[11px] hover:bg-bc-accent/30 w-full disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {busy ? <><FiLoader size={11} className="animate-spin" /> Analysing…</> : <>Analyse plan with AI</>}
+      </button>
+
+      {!backgroundPlan && <p className="text-gray-600 text-[9px]">Upload a plan above to enable analysis.</p>}
+      {error && <p className="text-bc-red text-[10px] break-words">{error}</p>}
+      {summary && <p className="text-bc-green text-[10px]">{summary}</p>}
+    </div>
+  );
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import type { BackgroundPlan, StageObjectType, Camera, CameraMountType, WallPatt
 import { MOUNT_TYPE_LABELS, MOUNT_HEIGHT_RANGE } from '../../types';
 import { CustomCameraForm } from './CustomCameraForm';
 import { CalculationBreakdown } from './CalculationBreakdown';
+import AiPlanAnalysis from './AiPlanAnalysis';
 import * as pdfjsLib from 'pdfjs-dist';
 
 /** Group lenses by mount for the dropdown */
@@ -1214,6 +1215,8 @@ export default function Sidebar() {
                 </button>
               </>
             )}
+            {/* AI floor-plan analysis (issues #39 / #40) */}
+            <AiPlanAnalysis />
           </div>
         )}
       </div>

--- a/src/utils/aiProviders.ts
+++ b/src/utils/aiProviders.ts
@@ -1,0 +1,213 @@
+// ── Multi-provider AI vision adapter (issues #39 / #40) ───────────────────────
+//
+// A small, provider-neutral layer that sends a floor-plan image + a prompt to
+// one of the five most common AI APIs and returns the raw text response. Each
+// provider is called via plain `fetch` against its public REST endpoint so the
+// browser bundle stays light and the call shape is uniform. The user picks the
+// provider and pastes their own API key (stored in localStorage); Gemini is
+// included because Google AI Studio hands out a free key.
+//
+// NOTE: outbound requests are gated by the app's Content-Security-Policy
+// (`connect-src`) — see index.html and electron/main.cjs. Browser CORS applies
+// in web builds; the Electron desktop build is the most reliable place to run
+// these calls.
+
+export type AiProviderId = 'gemini' | 'openai' | 'anthropic' | 'mistral' | 'xai';
+
+export interface PlanImage {
+  /** e.g. "image/png" */
+  mime: string;
+  /** base64 payload without the data: prefix */
+  base64: string;
+  /** full data URL (data:image/png;base64,...) */
+  dataUrl: string;
+}
+
+export interface AiProvider {
+  id: AiProviderId;
+  label: string;
+  /** Sensible default vision model — editable in the UI. */
+  defaultModel: string;
+  /** localStorage key holding this provider's API key. */
+  keyStorageKey: string;
+  /** Where the user gets a key (shown in the UI). */
+  keyHint: string;
+  /** True for providers that hand out a free key. */
+  free?: boolean;
+  /** Send image + prompt, resolve with the model's raw text answer. */
+  callVision: (apiKey: string, model: string, prompt: string, image: PlanImage) => Promise<string>;
+}
+
+/** Split a data URL into mime + base64. */
+export function splitDataUrl(dataUrl: string): PlanImage {
+  const match = /^data:([^;]+);base64,(.*)$/s.exec(dataUrl);
+  if (!match) throw new Error('Floor plan image is not a base64 data URL');
+  return { mime: match[1], base64: match[2], dataUrl };
+}
+
+/** Strip markdown fences and parse a JSON object out of a model response. */
+export function parseJsonResponse<T = unknown>(text: string): T {
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    // Models sometimes wrap JSON in ```json … ``` or add prose around it.
+    const fenced = trimmed.replace(/^```(?:json)?/i, '').replace(/```\s*$/, '').trim();
+    try {
+      return JSON.parse(fenced) as T;
+    } catch {
+      const start = fenced.indexOf('{');
+      const end = fenced.lastIndexOf('}');
+      if (start !== -1 && end > start) return JSON.parse(fenced.slice(start, end + 1)) as T;
+      throw new Error('Could not parse JSON from the AI response');
+    }
+  }
+}
+
+async function failOnError(res: Response, name: string): Promise<void> {
+  if (res.ok) return;
+  const body = await res.text().catch(() => '');
+  throw new Error(`${name} ${res.status}: ${body.slice(0, 240) || res.statusText}`);
+}
+
+// OpenAI / Mistral / xAI all speak the same chat-completions shape.
+async function callOpenAiCompatible(
+  endpoint: string,
+  name: string,
+  apiKey: string,
+  model: string,
+  prompt: string,
+  image: PlanImage,
+): Promise<string> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      model,
+      temperature: 0.1,
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: prompt },
+            { type: 'image_url', image_url: { url: image.dataUrl } },
+          ],
+        },
+      ],
+    }),
+  });
+  await failOnError(res, name);
+  const data = await res.json();
+  const text: string | undefined = data?.choices?.[0]?.message?.content;
+  if (!text) throw new Error(`${name} returned an empty response`);
+  return text;
+}
+
+export const AI_PROVIDERS: Record<AiProviderId, AiProvider> = {
+  gemini: {
+    id: 'gemini',
+    label: 'Google Gemini',
+    defaultModel: 'gemini-2.0-flash',
+    keyStorageKey: 'multicam-ai-key-gemini',
+    keyHint: 'Free key from aistudio.google.com',
+    free: true,
+    async callVision(apiKey, model, prompt, image) {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
+        body: JSON.stringify({
+          contents: [
+            {
+              role: 'user',
+              parts: [
+                { text: prompt },
+                { inline_data: { mime_type: image.mime, data: image.base64 } },
+              ],
+            },
+          ],
+          generationConfig: { responseMimeType: 'application/json', temperature: 0.1 },
+        }),
+      });
+      await failOnError(res, 'Gemini');
+      const data = await res.json();
+      const text: string | undefined = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (!text) throw new Error('Gemini returned an empty response');
+      return text;
+    },
+  },
+
+  openai: {
+    id: 'openai',
+    label: 'OpenAI (GPT)',
+    defaultModel: 'gpt-4o',
+    keyStorageKey: 'multicam-ai-key-openai',
+    keyHint: 'Key from platform.openai.com',
+    callVision(apiKey, model, prompt, image) {
+      return callOpenAiCompatible('https://api.openai.com/v1/chat/completions', 'OpenAI', apiKey, model, prompt, image);
+    },
+  },
+
+  anthropic: {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    defaultModel: 'claude-opus-4-8',
+    keyStorageKey: 'multicam-ai-key-anthropic',
+    keyHint: 'Key from console.anthropic.com',
+    async callVision(apiKey, model, prompt, image) {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          // Required to call the Messages API directly from a browser origin.
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 4096,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'image', source: { type: 'base64', media_type: image.mime, data: image.base64 } },
+                { type: 'text', text: prompt },
+              ],
+            },
+          ],
+        }),
+      });
+      await failOnError(res, 'Claude');
+      const data = await res.json();
+      const text: string | undefined = data?.content?.find((b: { type: string }) => b.type === 'text')?.text;
+      if (!text) throw new Error('Claude returned an empty response');
+      return text;
+    },
+  },
+
+  mistral: {
+    id: 'mistral',
+    label: 'Mistral (Pixtral)',
+    defaultModel: 'pixtral-12b-2409',
+    keyStorageKey: 'multicam-ai-key-mistral',
+    keyHint: 'Key from console.mistral.ai',
+    callVision(apiKey, model, prompt, image) {
+      return callOpenAiCompatible('https://api.mistral.ai/v1/chat/completions', 'Mistral', apiKey, model, prompt, image);
+    },
+  },
+
+  xai: {
+    id: 'xai',
+    label: 'xAI (Grok)',
+    defaultModel: 'grok-2-vision-1212',
+    keyStorageKey: 'multicam-ai-key-xai',
+    keyHint: 'Key from console.x.ai',
+    callVision(apiKey, model, prompt, image) {
+      return callOpenAiCompatible('https://api.x.ai/v1/chat/completions', 'Grok', apiKey, model, prompt, image);
+    },
+  },
+};
+
+export const AI_PROVIDER_ORDER: AiProviderId[] = ['gemini', 'openai', 'anthropic', 'mistral', 'xai'];

--- a/src/utils/planAnalysis.ts
+++ b/src/utils/planAnalysis.ts
@@ -1,0 +1,106 @@
+// ── AI floor-plan analysis: prompt + result mapping (issues #39 / #40) ────────
+//
+// The model receives the rendered floor-plan image and returns geometry as
+// *fractions* of the image (0..1, origin top-left). Working in fractions means
+// the model never has to know the real-world scale — we convert fractions to
+// metres on our side using the plan's own pixel size and scale, so walls and
+// stages line up with the plan whatever its calibration.
+
+import type { BackgroundPlan } from '../types';
+
+export interface PlanTasks {
+  walls: boolean;
+  stages: boolean;
+  scale: boolean;
+}
+
+export interface AnalysisResult {
+  walls?: { x1f: number; y1f: number; x2f: number; y2f: number; label?: string }[];
+  stages?: { xf: number; yf: number; wf: number; hf: number; label?: string }[];
+  scale?: { metersPerPixel: number | null; note?: string };
+}
+
+export function buildPlanPrompt(tasks: PlanTasks): string {
+  const wants: string[] = [];
+  if (tasks.walls) wants.push('walls');
+  if (tasks.stages) wants.push('stages');
+  if (tasks.scale) wants.push('scale');
+
+  const schema: string[] = ['{'];
+  if (tasks.walls) {
+    schema.push('  "walls": [{ "x1f": number, "y1f": number, "x2f": number, "y2f": number, "label": string }],');
+  }
+  if (tasks.stages) {
+    schema.push('  "stages": [{ "xf": number, "yf": number, "wf": number, "hf": number, "label": string }],');
+  }
+  if (tasks.scale) {
+    schema.push('  "scale": { "metersPerPixel": number | null, "note": string }');
+  }
+  schema.push('}');
+
+  return [
+    'You are an architectural floor-plan analyser for a broadcast camera planning tool.',
+    `Analyse the attached floor-plan image and extract: ${wants.join(', ')}.`,
+    '',
+    'Coordinate system: the image origin (0,0) is the TOP-LEFT corner, x increases',
+    'to the right, y increases downward. Express every coordinate as a FRACTION of',
+    'the image dimensions in the range 0..1 (so the centre of the image is 0.5, 0.5).',
+    '',
+    tasks.walls
+      ? '- walls: each straight wall segment as a line from (x1f,y1f) to (x2f,y2f). Trace the actual drawn walls; do not invent a bounding box. Give each a short label.'
+      : '',
+    tasks.stages
+      ? '- stages: each stage/podium/platform as an axis-aligned rectangle with top-left (xf,yf) and size (wf,hf) as fractions. Label each.'
+      : '',
+    tasks.scale
+      ? '- scale: if the plan shows a scale bar or a dimension annotation (e.g. "5 m", "1:100"), estimate metersPerPixel for this image and explain briefly in note. If you cannot determine it, return metersPerPixel: null.'
+      : '',
+    '',
+    'Return ONLY a JSON object matching this schema (no markdown, no commentary):',
+    ...schema,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function clampFrac(v: unknown): number {
+  const n = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+/** Convert an image fraction to a world X coordinate in metres for this plan. */
+function fracToX(plan: BackgroundPlan, xf: number): number {
+  return plan.offsetX + clampFrac(xf) * plan.widthPx * plan.scaleX;
+}
+function fracToY(plan: BackgroundPlan, yf: number): number {
+  return plan.offsetY + clampFrac(yf) * plan.heightPx * plan.scaleY;
+}
+
+export function wallsFromResult(
+  result: AnalysisResult,
+  plan: BackgroundPlan,
+): { x1: number; y1: number; x2: number; y2: number; label: string }[] {
+  if (!Array.isArray(result.walls)) return [];
+  return result.walls.map((w, i) => ({
+    x1: fracToX(plan, w.x1f),
+    y1: fracToY(plan, w.y1f),
+    x2: fracToX(plan, w.x2f),
+    y2: fracToY(plan, w.y2f),
+    label: (w.label && String(w.label)) || `AI Wall ${i + 1}`,
+  }));
+}
+
+export function stagesFromResult(
+  result: AnalysisResult,
+  plan: BackgroundPlan,
+): { x: number; y: number; width: number; height: number; label: string }[] {
+  if (!Array.isArray(result.stages)) return [];
+  return result.stages.map((s, i) => ({
+    x: fracToX(plan, s.xf),
+    y: fracToY(plan, s.yf),
+    width: Math.max(0.5, clampFrac(s.wf) * plan.widthPx * plan.scaleX),
+    height: Math.max(0.5, clampFrac(s.hf) * plan.heightPx * plan.scaleY),
+    label: (s.label && String(s.label)) || `AI Stage ${i + 1}`,
+  }));
+}


### PR DESCRIPTION
Implements the AI-from-PDF analysis requested for **#39** and the AI part of **#40** — a selectable multi-provider layer that reads the uploaded floor-plan image and extracts walls, stages and scale.

## The 5 selectable providers (all vision-capable)
| Provider | Default model | Key |
|---|---|---|
| **Google Gemini** | `gemini-2.0-flash` | **free** (aistudio.google.com) |
| OpenAI (GPT) | `gpt-4o` | platform.openai.com |
| Anthropic (Claude) | `claude-opus-4-8` | console.anthropic.com |
| Mistral (Pixtral) | `pixtral-12b-2409` | console.mistral.ai |
| xAI (Grok) | `grok-2-vision-1212` | console.x.ai |

Provider, API key and model are chosen in the UI; key + model persist per-provider in `localStorage`. Models are editable so users can pick a cheaper/newer one.

## How it works
- `src/utils/aiProviders.ts` — uniform `fetch`-based adapter. OpenAI/Mistral/xAI share the chat-completions shape; Gemini and Anthropic have their own. Anthropic sends the `anthropic-dangerous-direct-browser-access` header so it works from the renderer.
- `src/utils/planAnalysis.ts` — prompt builder + result mapping. The model returns **image-fraction** coordinates (0..1), which we convert to metres using the plan's own pixel size and scale, so geometry lines up regardless of calibration. When *Scale* is requested and the model returns metres/pixel, the scale is applied first and the geometry is computed against it.
- `src/components/Sidebar/AiPlanAnalysis.tsx` — panel in the **Floor Plan** section: provider dropdown, key/model inputs, **Walls / Stages / Scale** checkboxes, and an *Analyse plan with AI* button. Results are applied via `addWall` / `addStage` / `setBackgroundPlan`.
- CSP (`index.html` + `electron/main.cjs`): added the OpenAI/Anthropic/Mistral/xAI endpoints to `connect-src` (Gemini was already allowed).

## Notes
- Calls go directly from the client with the user's own key. Browser CORS applies in web builds; the Electron desktop build is the most reliable place to run them.
- Reuses the existing Gemini-key UX pattern already present in `CustomCameraForm.tsx`.

## Verification
- `npm run build` ✅ · `npm test` ✅ (47/47)
- Headless Chromium smoke test: AI panel renders in the Floor Plan section, all 5 providers listed (Gemini flagged *free key*), Analyse button + Gemini key hint present, **no JS console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011fJLgjChoGWcA5wRdZF5ri)_